### PR TITLE
User-friendly debugging of multiple threads in new Launch Control workflow

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -287,7 +287,10 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
      </widget>
     </item>
     <item row="4" column="0">
-     <widget class="QComboBox" name="comboBox">
+     <widget class="QComboBox" name="debug_comboBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
       <property name="styleSheet">
        <string notr="true">background-color: rgb(255, 255, 255)</string>
       </property>
@@ -299,10 +302,18 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
         <string>launch_control</string>
        </property>
       </item>
+      <item>
+       <property name="text">
+        <string>test</string>
+       </property>
+      </item>
      </widget>
     </item>
     <item row="3" column="0">
-     <widget class="QLabel" name="label_3">
+     <widget class="QLabel" name="debug_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
       </property>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -199,7 +199,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
      </widget>
     </item>
     <item row="2" column="0">
-     <widget class="QRadioButton" name="radioButton">
+     <widget class="QRadioButton" name="debug_radio_button">
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
       </property>
@@ -292,8 +292,13 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
        <string notr="true">background-color: rgb(255, 255, 255)</string>
       </property>
       <property name="currentText">
-       <string/>
+       <string>launch_control</string>
       </property>
+      <item>
+       <property name="text">
+        <string>launch_control</string>
+       </property>
+      </item>
      </widget>
     </item>
     <item row="3" column="0">

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -295,11 +295,11 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
        <string notr="true">background-color: rgb(255, 255, 255)</string>
       </property>
       <property name="currentText">
-       <string>launch_control</string>
+       <string>launcher_script</string>
       </property>
       <item>
        <property name="text">
-        <string>launch_control</string>
+        <string>launcher_script</string>
        </property>
       </item>
       <item>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -291,6 +291,9 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       <property name="enabled">
        <bool>false</bool>
       </property>
+        <property name="visible">
+        <bool>false</bool>
+        </property>
       <property name="styleSheet">
        <string notr="true">background-color: rgb(255, 255, 255)</string>
       </property>
@@ -304,7 +307,12 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </item>
       <item>
        <property name="text">
-        <string>test</string>
+        <string>launched_server</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>launched_gui</string>
        </property>
       </item>
      </widget>
@@ -314,6 +322,9 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       <property name="enabled">
        <bool>false</bool>
       </property>
+        <property name="visible">
+        <bool>false</bool>
+        </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
       </property>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -298,21 +298,21 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
        <string notr="true">background-color: rgb(255, 255, 255)</string>
       </property>
       <property name="currentText">
-       <string>launcher_script</string>
+       <string>launcher</string>
       </property>
       <item>
        <property name="text">
-        <string>launcher_script</string>
+        <string>launcher</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>launched_server</string>
+        <string>pylabnet_gui</string>
        </property>
       </item>
       <item>
        <property name="text">
-        <string>launched_gui</string>
+        <string>pylabnet_server</string>
        </property>
       </item>
      </widget>
@@ -329,7 +329,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
        <string notr="true">color: rgb(255, 255, 255);</string>
       </property>
       <property name="text">
-       <string>Debug Level:</string>
+       <string>Module:</string>
       </property>
      </widget>
     </item>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote_backup.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote_backup.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1526</width>
-    <height>499</height>
+    <height>512</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,13 +24,72 @@ selection-color: rgb(255, 0, 0);</string>
    <enum>Qt::ToolButtonIconOnly</enum>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
+   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0" columnstretch="0,0,0,0,0">
     <property name="leftMargin">
      <number>6</number>
     </property>
     <property name="bottomMargin">
      <number>6</number>
     </property>
+    <item row="3" column="3">
+     <widget class="QListWidget" name="client_list">
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(85, 170, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="4">
+     <widget class="QListWidget" name="script_list">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(0, 170, 127);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="flow">
+       <enum>QListView::TopToBottom</enum>
+      </property>
+      <property name="viewMode">
+       <enum>QListView::IconMode</enum>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="4">
      <widget class="QLabel" name="label_2">
       <property name="maximumSize">
@@ -176,7 +235,26 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="6" column="0">
+    <item row="3" column="1" colspan="2">
+     <widget class="QTextBrowser" name="terminal">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="font">
+       <font>
+        <family>Courier New</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
      <widget class="QTextBrowser" name="buffer_terminal">
       <property name="maximumSize">
        <size>
@@ -198,114 +276,6 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="0">
-     <widget class="QRadioButton" name="radioButton">
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Debug</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1" rowspan="5" colspan="2">
-     <widget class="QTextBrowser" name="terminal">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="font">
-       <font>
-        <family>Courier New</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="4" rowspan="5">
-     <widget class="QListWidget" name="script_list">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(0, 170, 127);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="flow">
-       <enum>QListView::TopToBottom</enum>
-      </property>
-      <property name="viewMode">
-       <enum>QListView::IconMode</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="3" rowspan="5">
-     <widget class="QListWidget" name="client_list">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(85, 170, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="0">
-     <widget class="QComboBox" name="comboBox">
-      <property name="styleSheet">
-       <string notr="true">background-color: rgb(255, 255, 255)</string>
-      </property>
-      <property name="currentText">
-       <string/>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_3">
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Debug Level:</string>
-      </property>
-     </widget>
-    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -314,7 +284,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
      <x>0</x>
      <y>0</y>
      <width>1526</width>
-     <height>21</height>
+     <height>31</height>
     </rect>
    </property>
   </widget>

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -52,6 +52,8 @@ class Controller:
         self.script_list = {}
         self.client_data = {}
         self.disconnection = False
+        self.debug = False
+        self.debug_level = None
         try:
             if sys.argv[1] == '-p':
                 self.proxy = True
@@ -320,15 +322,21 @@ class Controller:
         launch_time = time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime())
         print('Launching {} at {}'.format(script_to_run, launch_time))  # TODO MAKE A LOG STATEMENT
 
+        if self.debug and self.debug_level=="launcher_script":
+            debug_flag = '1'
+        else:
+            debug_flag = '0'
+
         # Build the bash command to input all active servers and relevant port numbers to script
-        bash_cmd = 'start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --numclients {}'.format(
+        bash_cmd = 'start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --numclients {} --debug {}'.format(
             script_to_run,
             launch_time,
             sys.executable,
             os.path.join(os.path.dirname(os.path.realpath(__file__)),script_to_run),
             self.host,
             self.log_port,
-            len(self.client_list)
+            len(self.client_list),
+            debug_flag
         )
         client_index = 1
         for client in self.client_list:
@@ -436,6 +444,7 @@ class Controller:
             self.main_window.debug_comboBox.setEnabled(True)
             self.main_window.debug_label.setHidden(False)
             self.main_window.debug_comboBox.setHidden(False)
+
         else:
             self.debug = False
             # Disable and hide combobox.
@@ -443,9 +452,15 @@ class Controller:
             self.main_window.debug_label.setHidden(True)
             self.main_window.debug_comboBox.setHidden(True)
 
-    def _update_debug_level(self, i):
+        # Update debug level.
+        self._update_debug_level(self)
+
+    def _update_debug_level(self, i=0):
         # Set debug level according to combo-box selection.
+        # Levels are:
+        # launcher_script
         self.debug_level = self.main_window.debug_comboBox.currentText()
+
 
 
 def main():

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -322,13 +322,19 @@ class Controller:
         launch_time = time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime())
         print('Launching {} at {}'.format(script_to_run, launch_time))  # TODO MAKE A LOG STATEMENT
 
-        if self.debug and self.debug_level=="launcher_script":
-            debug_flag = '1'
+        # Read debug state and set flag value accordingly.
+        if self.debug:
+            if self.debug_level=="launcher_script":
+                debug_flag = '1'
+            if self.debug_level=="launched_server":
+                server_debug_flag == '1'
+            if self.debug_level=="launched_gui":
+                gui_debug_flag == '1'
         else:
-            debug_flag = '0'
+            debug_flag, server_debug_flag, gui_debug_flag = '0', '0', '0'
 
         # Build the bash command to input all active servers and relevant port numbers to script
-        bash_cmd = 'start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --numclients {} --debug {}'.format(
+        bash_cmd = 'start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --numclients {} --debug {} --server_debug {} --gui_debug {}'.format(
             script_to_run,
             launch_time,
             sys.executable,
@@ -336,7 +342,9 @@ class Controller:
             self.host,
             self.log_port,
             len(self.client_list),
-            debug_flag
+            debug_flag,
+            server_debug_flag,
+            gui_debug_flag
         )
         client_index = 1
         for client in self.client_list:

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -266,6 +266,7 @@ class Controller:
         self._load_scripts()
         self._configure_clicks()
         self._configure_debug()
+        self._configure_debug_combo_select()
 
         self.main_window.force_update()
 
@@ -419,17 +420,32 @@ class Controller:
             self.main_window.client_list.takeItem(self.main_window.client_list.row(self.client_list[client]))
             del self.client_list[client]
 
-    # Defines what to do if debug radio button is clicked
+    # Defines what to do if debug radio button is clicked.
     def _configure_debug(self):
         self.main_window.debug_radio_button.toggled.connect(self._update_debug_settings)
+
+    # Defines what to do if combobox is changed.
+    def _configure_debug_combo_select(self):
+        self.main_window.debug_comboBox.currentIndexChanged.connect(self._update_debug_level)
 
     def _update_debug_settings(self):
         if self.main_window.debug_radio_button.isChecked():
             self.debug = True
-            self.main_window.debug_comboBox.setEnabled(False)
+
+            # Enable and show combobox.
+            self.main_window.debug_comboBox.setEnabled(True)
+            self.main_window.debug_label.setHidden(False)
+            self.main_window.debug_comboBox.setHidden(False)
         else:
             self.debug = False
+            # Disable and hide combobox.
             self.main_window.debug_comboBox.setEnabled(False)
+            self.main_window.debug_label.setHidden(True)
+            self.main_window.debug_comboBox.setHidden(True)
+
+    def _update_debug_level(self, i):
+        # Set debug level according to combo-box selection.
+        self.debug_level = self.main_window.debug_comboBox.currentText()
 
 
 def main():

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -329,11 +329,11 @@ class Controller:
 
         # Raise flags if selected in combobox
         if self.debug:
-            if self.debug_level == "launcher_script":
+            if self.debug_level == "launcher":
                 debug_flag = '1'
-            elif self.debug_level == "launched_server":
+            elif self.debug_level == "pylabnet_server":
                 server_debug_flag = '1'
-            elif self.debug_level == "launched_gui":
+            elif self.debug_level == "pylabnet_gui":
                 gui_debug_flag = '1'
 
         # Build the bash command to input all active servers and relevant port numbers to script
@@ -469,7 +469,7 @@ class Controller:
     def _update_debug_level(self, i=0):
         # Set debug level according to combo-box selection.
         # Levels are:
-        # launcher_script
+        # pylabnet_server, pylabnet_gui, launcher
         self.debug_level = self.main_window.debug_comboBox.currentText()
 
 

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -323,15 +323,18 @@ class Controller:
         print('Launching {} at {}'.format(script_to_run, launch_time))  # TODO MAKE A LOG STATEMENT
 
         # Read debug state and set flag value accordingly.
+
+        # Initial configurations: All flags down.
+        debug_flag, server_debug_flag, gui_debug_flag = '0', '0', '0'
+
+        # Raise flags if selected in combobox
         if self.debug:
-            if self.debug_level=="launcher_script":
+            if self.debug_level == "launcher_script":
                 debug_flag = '1'
-            if self.debug_level=="launched_server":
-                server_debug_flag == '1'
-            if self.debug_level=="launched_gui":
-                gui_debug_flag == '1'
-        else:
-            debug_flag, server_debug_flag, gui_debug_flag = '0', '0', '0'
+            elif self.debug_level == "launched_server":
+                server_debug_flag = '1'
+            elif self.debug_level == "launched_gui":
+                gui_debug_flag = '1'
 
         # Build the bash command to input all active servers and relevant port numbers to script
         bash_cmd = 'start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --numclients {} --debug {} --server_debug {} --gui_debug {}'.format(

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -5,17 +5,14 @@ import socket
 import os
 import time
 import subprocess
-import numpy as np
 from io import StringIO
 import re
 from pylabnet.utils.logging.logger import LogService
-from pylabnet.core.generic_server import GenericServer
 from PyQt5 import QtWidgets, QtGui, QtCore
 from pylabnet.gui.pyqt.external_gui import Window, Service, Client
 from pylabnet.core.generic_server import GenericServer
 from pylabnet.utils.logging.logger import LogClient
 from pylabnet.utils.helper_methods import dict_to_str, remove_spaces, create_server, show_console, hide_console
-import pickle
 
 
 if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
@@ -285,7 +282,7 @@ class Controller:
         new_msg = buffer_terminal[buffer_terminal.rfind(f'!~{self.update_index+1}~!'):-1]
 
         # Check if this failed
-        if new_msg is '':
+        if new_msg == '':
 
             # Check if the buffer is ahead of our last update
             up_str = re.findall(r'!~\d+~!', new_msg)
@@ -295,7 +292,7 @@ class Controller:
                     new_msg = buffer_terminal
 
         # If we have a new message to add, add it
-        if new_msg is not '':
+        if new_msg != '':
 
             self.main_window.terminal.append(re.sub(r'!~\d+~!', '', new_msg))
             try:
@@ -341,7 +338,7 @@ class Controller:
             script_to_run,
             launch_time,
             sys.executable,
-            os.path.join(os.path.dirname(os.path.realpath(__file__)),script_to_run),
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), script_to_run),
             self.host,
             self.log_port,
             len(self.client_list),
@@ -473,10 +470,8 @@ class Controller:
         self.debug_level = self.main_window.debug_comboBox.currentText()
 
 
-
 def main():
     """ Runs the launch controller """
-
 
     log_controller = Controller()
 
@@ -499,7 +494,7 @@ def main():
             log_controller.main_window.update_widgets()
 
             # New terminal input
-            if sys.stdout.getvalue() is not '':
+            if sys.stdout.getvalue() != '':
 
                 # Check for disconnection events
                 log_controller.check_disconnection()

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -120,7 +120,7 @@ class Launcher:
             import ptvsd
             import os
             # 5678 is the default attach port in the VS Code debug configurations
-            self.logger.info(f"Waiting for debugger attach to PID {os.getpid()} (launcher)")
+            self.logger.info(f"Waiting for debugger to attach to PID {os.getpid()} (launcher)")
             ptvsd.enable_attach(address=('localhost', 5678))
             ptvsd.wait_for_attach()
             breakpoint()

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -189,7 +189,7 @@ class Launcher:
                     gui+'_GUI',
                     time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime()),
                     sys.executable,
-                    os.path.join(os.path.dirname(os.path.realpath(__file__)),self._GUI_LAUNCH_SCRIPT),
+                    os.path.join(os.path.dirname(os.path.realpath(__file__)), self._GUI_LAUNCH_SCRIPT),
                     self.log_ip,
                     self.log_port,
                     gui_port,
@@ -268,7 +268,7 @@ class Launcher:
                     print(msg_str)
                     for index, match in enumerate(matches):
                         msg_str = ('------------------------------------------\n'
-                                   +'                    ({})                   \n'.format(index + 1)
+                                   + '                    ({})                   \n'.format(index + 1)
                                    + match.summarize())
                         print(msg_str)
                         self.logger.info(msg_str)
@@ -307,7 +307,7 @@ class Launcher:
                     server+"_server",
                     time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime()),
                     sys.executable,
-                    os.path.join(os.path.dirname(os.path.realpath(__file__)),self._SERVER_LAUNCH_SCRIPT),
+                    os.path.join(os.path.dirname(os.path.realpath(__file__)), self._SERVER_LAUNCH_SCRIPT),
                     self.log_ip,
                     self.log_port,
                     server_port,

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -82,7 +82,6 @@ class Launcher:
             Launcher object. Can be left blank, and the names of the script module(s) will be used
         :param params: (list) parameters for each script to launch
         """
-
         self.script = script
         self.server_req = server_req
         self.gui_req = gui_req
@@ -112,6 +111,16 @@ class Launcher:
 
         # Connect to logger
         self.logger = self._connect_to_logger()
+
+        # Halt execution and wait for debugger connection if debug flag is up.
+        if int(self.args['debug']) == 1:
+            import ptvsd
+            import os
+            # 5678 is the default attach port in the VS Code debug configurations
+            self.logger.info(f"Waiting for debugger attach to PID {os.getpid()}")
+            ptvsd.enable_attach(address=('localhost', 5678))
+            ptvsd.wait_for_attach()
+            breakpoint()
 
         # Find all servers with port numbers and store them as a dictionary
         self.connectors = {}

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -112,7 +112,7 @@ class Launcher:
         except IndexError:
             raise
 
-        # Connect to logger
+        # Connect to logger.
         self.logger = self._connect_to_logger()
 
         # Halt execution and wait for debugger connection if debug flag is up.
@@ -120,7 +120,7 @@ class Launcher:
             import ptvsd
             import os
             # 5678 is the default attach port in the VS Code debug configurations
-            self.logger.info(f"Waiting for debugger attach to PID {os.getpid()} (launcher_script)")
+            self.logger.info(f"Waiting for debugger attach to PID {os.getpid()} (launcher)")
             ptvsd.enable_attach(address=('localhost', 5678))
             ptvsd.wait_for_attach()
             breakpoint()

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -106,6 +106,9 @@ class Launcher:
             self.log_ip = self.args['logip']
             self.log_port = int(self.args['logport'])
             self.num_clients = int(self.args['numclients'])
+            self.debug = int(self.args['debug'])
+            self.server_debug = int(self.args['server_debug'])
+            self.gui_debug = int(self.args['gui_debug'])
         except IndexError:
             raise
 
@@ -113,11 +116,11 @@ class Launcher:
         self.logger = self._connect_to_logger()
 
         # Halt execution and wait for debugger connection if debug flag is up.
-        if int(self.args['debug']) == 1:
+        if self.debug == 1:
             import ptvsd
             import os
             # 5678 is the default attach port in the VS Code debug configurations
-            self.logger.info(f"Waiting for debugger attach to PID {os.getpid()}")
+            self.logger.info(f"Waiting for debugger attach to PID {os.getpid()} (launcher_script)")
             ptvsd.enable_attach(address=('localhost', 5678))
             ptvsd.wait_for_attach()
             breakpoint()
@@ -182,7 +185,7 @@ class Launcher:
         while not connected and timeout < 1000:
             try:
                 gui_port = np.random.randint(1, 9999)
-                subprocess.Popen('start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --guiport {} --ui {}'.format(
+                subprocess.Popen('start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --guiport {} --ui {} --debug {}'.format(
                     gui+'_GUI',
                     time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime()),
                     sys.executable,
@@ -190,7 +193,8 @@ class Launcher:
                     self.log_ip,
                     self.log_port,
                     gui_port,
-                    gui
+                    gui,
+                    self.gui_debug
                 ), shell=True)
                 connected = True
             except ConnectionRefusedError:
@@ -299,7 +303,7 @@ class Launcher:
                 server_port = np.random.randint(1, 9999)
                 server = module.__name__.split('.')[-1]
 
-                cmd = 'start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --serverport {} --server {}'.format(
+                cmd = 'start /min "{}, {}" /wait "{}" "{}" --logip {} --logport {} --serverport {} --server {} --debug {}'.format(
                     server+"_server",
                     time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime()),
                     sys.executable,
@@ -307,7 +311,8 @@ class Launcher:
                     self.log_ip,
                     self.log_port,
                     server_port,
-                    server
+                    server,
+                    self.server_debug
                 )
 
                 subprocess.Popen(cmd, shell=True)

--- a/pylabnet/launchers/pylabnet_gui.py
+++ b/pylabnet/launchers/pylabnet_gui.py
@@ -21,7 +21,6 @@ from pylabnet.utils.helper_methods import parse_args, show_console, hide_console
 
 import sys
 import socket
-import numpy as np
 
 # Should help with scaling issues on monitors of differing resolution
 if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):

--- a/pylabnet/launchers/pylabnet_gui.py
+++ b/pylabnet/launchers/pylabnet_gui.py
@@ -65,6 +65,18 @@ def main():
         server_port=gui_port
     )
 
+    # Retrieve debug flag.
+    debug = int(args['debug'])
+
+    if debug:
+        import ptvsd
+        import os
+        # 5678 is the default attach port in the VS Code debug configurations
+        gui_logger.info(f"Waiting for debugger attach to PID {os.getpid()} (pylabnet_gui)")
+        ptvsd.enable_attach(address=('localhost', 5678))
+        ptvsd.wait_for_attach()
+        breakpoint()
+
     gui_logger.info('Logging for gui template: {}'.format(gui_template))
 
     # Create app and instantiate main window

--- a/pylabnet/launchers/pylabnet_gui.py
+++ b/pylabnet/launchers/pylabnet_gui.py
@@ -72,7 +72,7 @@ def main():
         import ptvsd
         import os
         # 5678 is the default attach port in the VS Code debug configurations
-        gui_logger.info(f"Waiting for debugger attach to PID {os.getpid()} (pylabnet_gui)")
+        gui_logger.info(f"Waiting for debugger to attach to PID {os.getpid()} (pylabnet_gui)")
         ptvsd.enable_attach(address=('localhost', 5678))
         ptvsd.wait_for_attach()
         breakpoint()

--- a/pylabnet/launchers/pylabnet_gui.py
+++ b/pylabnet/launchers/pylabnet_gui.py
@@ -68,6 +68,7 @@ def main():
     # Retrieve debug flag.
     debug = int(args['debug'])
 
+    # Halt execution and wait for debugger connection if debug flag is up.
     if debug:
         import ptvsd
         import os

--- a/pylabnet/launchers/pylabnet_server.py
+++ b/pylabnet/launchers/pylabnet_server.py
@@ -72,6 +72,18 @@ def main():
         server_port=server_port
     )
 
+    # Retrieve debug flag.
+    debug = int(args['debug'])
+
+    if debug:
+        import ptvsd
+        import os
+        # 5678 is the default attach port in the VS Code debug configurations
+        server_logger.info(f"Waiting for debugger attach to PID {os.getpid()} (pylabnet_server)")
+        ptvsd.enable_attach(address=('localhost', 5678))
+        ptvsd.wait_for_attach()
+        breakpoint()
+
     # Instantiate module
     mod_inst = getattr(sys.modules[__name__], server)
     mod_inst.launch(logger=server_logger, port=server_port)

--- a/pylabnet/launchers/pylabnet_server.py
+++ b/pylabnet/launchers/pylabnet_server.py
@@ -80,7 +80,7 @@ def main():
         import ptvsd
         import os
         # 5678 is the default attach port in the VS Code debug configurations
-        server_logger.info(f"Waiting for debugger attach to PID {os.getpid()} (pylabnet_server)")
+        server_logger.info(f"Waiting for debugger to attach to PID {os.getpid()} (pylabnet_server)")
         ptvsd.enable_attach(address=('localhost', 5678))
         ptvsd.wait_for_attach()
         breakpoint()

--- a/pylabnet/launchers/pylabnet_server.py
+++ b/pylabnet/launchers/pylabnet_server.py
@@ -75,6 +75,7 @@ def main():
     # Retrieve debug flag.
     debug = int(args['debug'])
 
+    # Halt execution and wait for debugger connection if debug flag is up.
     if debug:
         import ptvsd
         import os

--- a/setup/env_file.yml
+++ b/setup/env_file.yml
@@ -274,5 +274,5 @@ dependencies:
     - pyqtgraph==0.10.0
     - pyvisa==1.10.1
     - retrying==1.3.3
-    - rpyc==4.1.1
     - zhinst==20.1.1211
+    - ptvsd==4.3.2

--- a/setup/env_file.yml
+++ b/setup/env_file.yml
@@ -274,5 +274,6 @@ dependencies:
     - pyqtgraph==0.10.0
     - pyvisa==1.10.1
     - retrying==1.3.3
+    - rpyc==4.1.1
     - zhinst==20.1.1211
     - ptvsd==4.3.2


### PR DESCRIPTION
This should close #31 . The new launcher flow includes multithreading, which makes debugging using the VS code (or any other) debugger difficult. Specifically, the `launch_control` module opens a new process which executes the `launcher` module, which itself launches the `pylabnet_gui` and the `pylabnet_server` modules in two new processes. Executing a script using the Launch Control window thus starts three new processes.

In this branch, I've added a debug radiobox which if selected shows a dropdown menu offering the possibility to add breakpoints at any three of the new processes:

![image](https://user-images.githubusercontent.com/4958226/82391044-4c630980-9a0e-11ea-9153-883dff05497f.png)

If for example the debug option `launcher` is chosen, the code execution will be halted at the beginning of the `launcher` module and the corresponding process ID (PID) will be displayed in the logger window:

![image](https://user-images.githubusercontent.com/4958226/82391611-b29c5c00-9a0f-11ea-8ebd-b4e3c7867c96.png)

Now, it is very easy to use the VS code debugger to attach to this process by using the following debug configuration in the `launch.json` setting of the VS code debugger:

```json
        {
            "name": "Python: attach to launcher",
            "type": "python",
            "request": "attach",
            "port": 5678,
            "host": "localhost",
            "redirectOutput" : true,
            "processId": "${command:pickProcess}"
        },
```

Using the PID from the logger, we can now easily attach the debugger to the process:
![image](https://user-images.githubusercontent.com/4958226/82391571-98627e00-9a0f-11ea-9d0a-f77a33e1562e.png).