### PR TITLE
logfile

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1526</width>
-    <height>499</height>
+    <height>731</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,61 +24,45 @@ selection-color: rgb(255, 0, 0);</string>
    <enum>Qt::ToolButtonIconOnly</enum>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
-    <property name="leftMargin">
-     <number>6</number>
-    </property>
-    <property name="bottomMargin">
-     <number>6</number>
-    </property>
-    <item row="4" column="0">
-     <widget class="QComboBox" name="debug_comboBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="visible">
-       <bool>false</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: rgb(255, 255, 255)</string>
-      </property>
-      <property name="currentText">
-       <string>launcher</string>
-      </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="8" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <property name="text">
-        <string>launcher</string>
-       </property>
+       <widget class="QPushButton" name="logfile_status_button">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: rgb(255, 255, 255);
+background-color: green;</string>
+        </property>
+        <property name="text">
+         <string>Start logging to file</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
       <item>
-       <property name="text">
-        <string>pylabnet_gui</string>
-       </property>
+       <widget class="QRadioButton" name="log_previous">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: rgb(255, 255, 255);</string>
+        </property>
+        <property name="text">
+         <string>Log Previous</string>
+        </property>
+        <property name="autoExclusive">
+         <bool>false</bool>
+        </property>
+       </widget>
       </item>
-      <item>
-       <property name="text">
-        <string>pylabnet_server</string>
-       </property>
-      </item>
-     </widget>
+     </layout>
     </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="debug_label">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="visible">
-       <bool>false</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Module:</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="3" rowspan="7">
+    <item row="2" column="2" rowspan="8">
      <widget class="QListWidget" name="client_list">
       <property name="maximumSize">
        <size>
@@ -103,186 +87,7 @@ selection-color: rgb(255, 0, 0);</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="4" rowspan="7">
-     <widget class="QListWidget" name="script_list">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(0, 170, 127);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="flow">
-       <enum>QListView::TopToBottom</enum>
-      </property>
-      <property name="viewMode">
-       <enum>QListView::IconMode</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="0">
-     <widget class="QTextBrowser" name="buffer_terminal">
-      <property name="maximumSize">
-       <size>
-        <width>100</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="verticalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="overwriteMode">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QRadioButton" name="debug_radio_button">
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Debug</string>
-      </property>
-      <property name="autoExclusive">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1" rowspan="7" colspan="2">
-     <widget class="QTextBrowser" name="terminal">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="font">
-       <font>
-        <family>Courier New</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="3" rowspan="2">
-     <widget class="QLabel" name="label">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(85, 170, 255);</string>
-      </property>
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Log Clients:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="4">
-     <widget class="QLabel" name="label_2">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(0, 170, 127);</string>
-      </property>
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Scripts to launch:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QPushButton" name="stop_button">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>100</width>
-        <height>100</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>14</pointsize>
-       </font>
-      </property>
-      <property name="mouseTracking">
-       <bool>false</bool>
-      </property>
-      <property name="autoFillBackground">
-       <bool>false</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: rgb(170, 170, 255);</string>
-      </property>
-      <property name="text">
-       <string>STOP</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="0">
-     <widget class="QTreeView" name="file_viewer">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: rgb(211, 211, 211);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
+    <item row="1" column="1">
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <property name="spacing">
        <number>100</number>
@@ -349,7 +154,195 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </item>
      </layout>
     </item>
-    <item row="5" column="0">
+    <item row="1" column="0">
+     <widget class="QPushButton" name="stop_button">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>100</width>
+        <height>100</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>14</pointsize>
+       </font>
+      </property>
+      <property name="mouseTracking">
+       <bool>false</bool>
+      </property>
+      <property name="autoFillBackground">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(170, 170, 255);</string>
+      </property>
+      <property name="text">
+       <string>STOP</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QComboBox" name="debug_comboBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="visible">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(255, 255, 255)</string>
+      </property>
+      <property name="currentText">
+       <string>launcher</string>
+      </property>
+      <item>
+       <property name="text">
+        <string>launcher</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_gui</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_server</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="1" column="2">
+     <widget class="QLabel" name="label">
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(85, 170, 255);</string>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Log Clients:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="3">
+     <widget class="QLabel" name="label_2">
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(0, 170, 127);</string>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Scripts to launch:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="debug_radio_button">
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Debug</string>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1" rowspan="6">
+     <widget class="QTextBrowser" name="terminal">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="font">
+       <font>
+        <family>Courier New</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="0">
+     <widget class="QTreeView" name="file_viewer">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(211, 211, 211);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="3" rowspan="8">
+     <widget class="QListWidget" name="script_list">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(0, 170, 127);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="flow">
+       <enum>QListView::TopToBottom</enum>
+      </property>
+      <property name="viewMode">
+       <enum>QListView::IconMode</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0">
      <widget class="QRadioButton" name="log_file_button">
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -362,20 +355,41 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="7" column="0">
-     <widget class="QPushButton" name="logfile_status_button">
+    <item row="9" column="0">
+     <widget class="QTextBrowser" name="buffer_terminal">
+      <property name="maximumSize">
+       <size>
+        <width>100</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="verticalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="overwriteMode">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="debug_label">
       <property name="enabled">
        <bool>false</bool>
       </property>
+      <property name="visible">
+       <bool>true</bool>
+      </property>
       <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);
-background-color: green;</string>
+       <string notr="true">color: rgb(255, 255, 255);</string>
       </property>
       <property name="text">
-       <string>Start logging to file</string>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
+       <string>Module:</string>
       </property>
      </widget>
     </item>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1526</width>
-    <height>731</height>
+    <height>784</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,7 +25,80 @@ selection-color: rgb(255, 0, 0);</string>
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
-    <item row="8" column="0">
+    <item row="3" column="0" colspan="2">
+     <widget class="QComboBox" name="debug_comboBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="visible">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(255, 255, 255)</string>
+      </property>
+      <property name="currentText">
+       <string>launcher</string>
+      </property>
+      <item>
+       <property name="text">
+        <string>launcher</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_gui</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_server</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="5" column="0" colspan="2">
+     <widget class="QTreeView" name="file_viewer">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(211, 211, 211);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0" colspan="2">
+     <widget class="QLabel" name="debug_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="visible">
+       <bool>true</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Module:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0" colspan="2">
+     <widget class="QRadioButton" name="log_file_button">
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Log File Setup</string>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0" rowspan="2" colspan="2">
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QPushButton" name="logfile_status_button">
@@ -60,34 +133,41 @@ background-color: green;</string>
         </property>
        </widget>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="styleSheet">
+           <string notr="true">color: rgb(255, 255, 255);</string>
+          </property>
+          <property name="text">
+           <string>Logging to file?</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="logfile_status_indicator">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normaloff>green_LED_off.svg</normaloff>
+            <normalon>green_LED_on.svg</normalon>
+            <disabledoff>green_LED_off.svg</disabledoff>
+            <disabledon>green_LED_on.svg</disabledon>
+            <activeoff>green_LED_on.svg</activeoff>green_LED_off.svg</iconset>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </item>
-    <item row="2" column="2" rowspan="8">
-     <widget class="QListWidget" name="client_list">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(85, 170, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
+    <item row="0" column="2">
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <property name="spacing">
        <number>100</number>
@@ -154,7 +234,42 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </item>
      </layout>
     </item>
-    <item row="1" column="0">
+    <item row="0" column="4">
+     <widget class="QLabel" name="label_2">
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(0, 170, 127);</string>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Scripts to launch:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0" colspan="2">
+     <widget class="QRadioButton" name="debug_radio_button">
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Debug</string>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0" colspan="2">
      <widget class="QPushButton" name="stop_button">
       <property name="enabled">
        <bool>true</bool>
@@ -188,38 +303,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="4" column="0">
-     <widget class="QComboBox" name="debug_comboBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="visible">
-       <bool>true</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: rgb(255, 255, 255)</string>
-      </property>
-      <property name="currentText">
-       <string>launcher</string>
-      </property>
-      <item>
-       <property name="text">
-        <string>launcher</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>pylabnet_gui</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>pylabnet_server</string>
-       </property>
-      </item>
-     </widget>
-    </item>
-    <item row="1" column="2">
+    <item row="0" column="3">
      <widget class="QLabel" name="label">
       <property name="maximumSize">
        <size>
@@ -241,8 +325,49 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="1" column="3">
-     <widget class="QLabel" name="label_2">
+    <item row="8" column="0">
+     <widget class="QTextBrowser" name="buffer_terminal">
+      <property name="maximumSize">
+       <size>
+        <width>100</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="verticalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="overwriteMode">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="2" rowspan="8">
+     <widget class="QTextBrowser" name="terminal">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="font">
+       <font>
+        <family>Courier New</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="3" rowspan="8">
+     <widget class="QListWidget" name="client_list">
       <property name="maximumSize">
        <size>
         <width>200</width>
@@ -255,41 +380,18 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
         <pointsize>12</pointsize>
        </font>
       </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(0, 170, 127);</string>
-      </property>
-      <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Scripts to launch:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QRadioButton" name="debug_radio_button">
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Debug</string>
-      </property>
-      <property name="autoExclusive">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="0">
-     <widget class="QTreeView" name="file_viewer">
-      <property name="enabled">
-       <bool>false</bool>
+      <property name="toolTip">
+       <string/>
       </property>
       <property name="styleSheet">
-       <string notr="true">background-color: rgb(211, 211, 211);</string>
+       <string notr="true">color: rgb(85, 170, 255);</string>
       </property>
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
       </property>
      </widget>
     </item>
-    <item row="2" column="3" rowspan="8">
+    <item row="1" column="4" rowspan="8">
      <widget class="QListWidget" name="script_list">
       <property name="enabled">
        <bool>true</bool>
@@ -320,76 +422,6 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
       <property name="viewMode">
        <enum>QListView::IconMode</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="0">
-     <widget class="QRadioButton" name="log_file_button">
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Log File</string>
-      </property>
-      <property name="autoExclusive">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="0">
-     <widget class="QTextBrowser" name="buffer_terminal">
-      <property name="maximumSize">
-       <size>
-        <width>100</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="verticalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="overwriteMode">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="debug_label">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="visible">
-       <bool>true</bool>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Module:</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1" rowspan="8">
-     <widget class="QTextBrowser" name="terminal">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="font">
-       <font>
-        <family>Courier New</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
       </property>
      </widget>
     </item>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -24,7 +24,7 @@ selection-color: rgb(255, 0, 0);</string>
    <enum>Qt::ToolButtonIconOnly</enum>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
+   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
     <property name="leftMargin">
      <number>6</number>
     </property>
@@ -78,7 +78,7 @@ selection-color: rgb(255, 0, 0);</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="3" rowspan="6">
+    <item row="2" column="3" rowspan="7">
      <widget class="QListWidget" name="client_list">
       <property name="maximumSize">
        <size>
@@ -103,7 +103,7 @@ selection-color: rgb(255, 0, 0);</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="4" rowspan="6">
+    <item row="2" column="4" rowspan="7">
      <widget class="QListWidget" name="script_list">
       <property name="enabled">
        <bool>true</bool>
@@ -137,7 +137,7 @@ selection-color: rgb(255, 0, 0);</string>
       </property>
      </widget>
     </item>
-    <item row="7" column="0">
+    <item row="8" column="0">
      <widget class="QTextBrowser" name="buffer_terminal">
       <property name="maximumSize">
        <size>
@@ -172,7 +172,7 @@ selection-color: rgb(255, 0, 0);</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="1" rowspan="6" colspan="2">
+    <item row="2" column="1" rowspan="7" colspan="2">
      <widget class="QTextBrowser" name="terminal">
       <property name="enabled">
        <bool>true</bool>
@@ -269,6 +269,19 @@ selection-color: rgb(255, 0, 0);</string>
       </property>
      </widget>
     </item>
+    <item row="6" column="0">
+     <widget class="QTreeView" name="file_viewer">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(170, 170, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="1">
      <layout class="QHBoxLayout" name="horizontalLayout_5">
       <property name="spacing">
@@ -337,7 +350,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
      </layout>
     </item>
     <item row="5" column="0">
-     <widget class="QRadioButton" name="log_file">
+     <widget class="QRadioButton" name="log_file_button">
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
       </property>
@@ -349,13 +362,20 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="6" column="0">
-     <widget class="QTreeView" name="file_viewer">
+    <item row="7" column="0">
+     <widget class="QPushButton" name="logfile_status_button">
       <property name="enabled">
        <bool>false</bool>
       </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);
+background-color: green;</string>
+      </property>
+      <property name="text">
+       <string>Start Logging</string>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
       </property>
      </widget>
     </item>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -24,13 +24,195 @@ selection-color: rgb(255, 0, 0);</string>
    <enum>Qt::ToolButtonIconOnly</enum>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
+   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
     <property name="leftMargin">
      <number>6</number>
     </property>
     <property name="bottomMargin">
      <number>6</number>
     </property>
+    <item row="4" column="0">
+     <widget class="QComboBox" name="debug_comboBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(255, 255, 255)</string>
+      </property>
+      <property name="currentText">
+       <string>launcher</string>
+      </property>
+      <item>
+       <property name="text">
+        <string>launcher</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_gui</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_server</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="debug_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Module:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="3" rowspan="6">
+     <widget class="QListWidget" name="client_list">
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(85, 170, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="4" rowspan="6">
+     <widget class="QListWidget" name="script_list">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(0, 170, 127);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="flow">
+       <enum>QListView::TopToBottom</enum>
+      </property>
+      <property name="viewMode">
+       <enum>QListView::IconMode</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="7" column="0">
+     <widget class="QTextBrowser" name="buffer_terminal">
+      <property name="maximumSize">
+       <size>
+        <width>100</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="verticalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="overwriteMode">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="debug_radio_button">
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Debug</string>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1" rowspan="6" colspan="2">
+     <widget class="QTextBrowser" name="terminal">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="font">
+       <font>
+        <family>Courier New</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="3" rowspan="2">
+     <widget class="QLabel" name="label">
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(85, 170, 255);</string>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Log Clients:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
     <item row="0" column="4">
      <widget class="QLabel" name="label_2">
       <property name="maximumSize">
@@ -154,182 +336,26 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </item>
      </layout>
     </item>
-    <item row="0" column="3" rowspan="2">
-     <widget class="QLabel" name="label">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
+    <item row="5" column="0">
+     <widget class="QRadioButton" name="log_file">
       <property name="styleSheet">
-       <string notr="true">color: rgb(85, 170, 255);</string>
+       <string notr="true">color: rgb(255, 255, 255);</string>
       </property>
       <property name="text">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Log Clients:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <string>Log File</string>
+      </property>
+      <property name="autoExclusive">
+       <bool>false</bool>
       </property>
      </widget>
     </item>
     <item row="6" column="0">
-     <widget class="QTextBrowser" name="buffer_terminal">
-      <property name="maximumSize">
-       <size>
-        <width>100</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="verticalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="overwriteMode">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QRadioButton" name="debug_radio_button">
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Debug</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1" rowspan="5" colspan="2">
-     <widget class="QTextBrowser" name="terminal">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="font">
-       <font>
-        <family>Courier New</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="4" rowspan="5">
-     <widget class="QListWidget" name="script_list">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(0, 170, 127);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="flow">
-       <enum>QListView::TopToBottom</enum>
-      </property>
-      <property name="viewMode">
-       <enum>QListView::IconMode</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="3" rowspan="5">
-     <widget class="QListWidget" name="client_list">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(85, 170, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="0">
-     <widget class="QComboBox" name="debug_comboBox">
+     <widget class="QTreeView" name="file_viewer">
       <property name="enabled">
        <bool>false</bool>
       </property>
-        <property name="visible">
-        <bool>false</bool>
-        </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: rgb(255, 255, 255)</string>
-      </property>
-      <property name="currentText">
-       <string>launcher</string>
-      </property>
-      <item>
-       <property name="text">
-        <string>launcher</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>pylabnet_gui</string>
-       </property>
-      </item>
-      <item>
-       <property name="text">
-        <string>pylabnet_server</string>
-       </property>
-      </item>
-     </widget>
-    </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="debug_label">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-        <property name="visible">
-        <bool>false</bool>
-        </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Module:</string>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
       </property>
      </widget>
     </item>
@@ -341,7 +367,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
      <x>0</x>
      <y>0</y>
      <width>1526</width>
-     <height>21</height>
+     <height>38</height>
     </rect>
    </property>
   </widget>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -276,25 +276,6 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="1" rowspan="6">
-     <widget class="QTextBrowser" name="terminal">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="font">
-       <font>
-        <family>Courier New</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
     <item row="7" column="0">
      <widget class="QTreeView" name="file_viewer">
       <property name="enabled">
@@ -390,6 +371,25 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
       <property name="text">
        <string>Module:</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1" rowspan="8">
+     <widget class="QTextBrowser" name="terminal">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="font">
+       <font>
+        <family>Courier New</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
       </property>
      </widget>
     </item>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -275,7 +275,7 @@ selection-color: rgb(255, 0, 0);</string>
        <bool>false</bool>
       </property>
       <property name="styleSheet">
-       <string notr="true">background-color: rgb(170, 170, 255);</string>
+       <string notr="true">background-color: rgb(211, 211, 211);</string>
       </property>
       <property name="frameShape">
        <enum>QFrame::NoFrame</enum>
@@ -372,7 +372,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
 background-color: green;</string>
       </property>
       <property name="text">
-       <string>Start Logging</string>
+       <string>Start logging to file</string>
       </property>
       <property name="checkable">
        <bool>true</bool>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote_backup.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote_backup.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1526</width>
-    <height>512</height>
+    <height>499</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,72 +24,13 @@ selection-color: rgb(255, 0, 0);</string>
    <enum>Qt::ToolButtonIconOnly</enum>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0" columnstretch="0,0,0,0,0">
+   <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0" columnstretch="0,0,0,0,0">
     <property name="leftMargin">
      <number>6</number>
     </property>
     <property name="bottomMargin">
      <number>6</number>
     </property>
-    <item row="3" column="3">
-     <widget class="QListWidget" name="client_list">
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(85, 170, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="4">
-     <widget class="QListWidget" name="script_list">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <family>Calibri Light</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(0, 170, 127);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="flow">
-       <enum>QListView::TopToBottom</enum>
-      </property>
-      <property name="viewMode">
-       <enum>QListView::IconMode</enum>
-      </property>
-     </widget>
-    </item>
     <item row="0" column="4">
      <widget class="QLabel" name="label_2">
       <property name="maximumSize">
@@ -235,26 +176,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
-    <item row="3" column="1" colspan="2">
-     <widget class="QTextBrowser" name="terminal">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="font">
-       <font>
-        <family>Courier New</family>
-        <pointsize>12</pointsize>
-       </font>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0">
+    <item row="6" column="0">
      <widget class="QTextBrowser" name="buffer_terminal">
       <property name="maximumSize">
        <size>
@@ -276,6 +198,141 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       </property>
      </widget>
     </item>
+    <item row="2" column="0">
+     <widget class="QRadioButton" name="debug_radio_button">
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Debug</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1" rowspan="5" colspan="2">
+     <widget class="QTextBrowser" name="terminal">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="font">
+       <font>
+        <family>Courier New</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="4" rowspan="5">
+     <widget class="QListWidget" name="script_list">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(0, 170, 127);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="flow">
+       <enum>QListView::TopToBottom</enum>
+      </property>
+      <property name="viewMode">
+       <enum>QListView::IconMode</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="3" rowspan="5">
+     <widget class="QListWidget" name="client_list">
+      <property name="maximumSize">
+       <size>
+        <width>200</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <family>Calibri Light</family>
+        <pointsize>12</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(85, 170, 255);</string>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0">
+     <widget class="QComboBox" name="debug_comboBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">background-color: rgb(255, 255, 255)</string>
+      </property>
+      <property name="currentText">
+       <string>launcher</string>
+      </property>
+      <item>
+       <property name="text">
+        <string>launcher</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_gui</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>pylabnet_server</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="debug_label">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="visible">
+       <bool>false</bool>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Module:</string>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -284,7 +341,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
      <x>0</x>
      <y>0</y>
      <width>1526</width>
-     <height>31</height>
+     <height>38</height>
     </rect>
    </property>
   </widget>

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -500,8 +500,6 @@ class Controller:
                 model.setRootPath(QtCore.QDir.rootPath())
                 self.main_window.file_viewer.setModel(model)
                 self.main_window.file_viewer.setRootIndex(model.index(QtCore.QDir.homePath()))
-                # selection_model = QtCore.QItemSelectionModel()
-                # self.main_window.file_viewer.setSelectionModel(selection_model)
 
         else:
 
@@ -524,19 +522,17 @@ class Controller:
 
             # Actually start logging
             self.log_file = True
-            # filename = f'logfile_{datetime.now().strftime("%H_%M_%S")}'
+            filename = f'logfile_{datetime.now().strftime("%H_%M_%S")}'
             try:
-                # self.log_service.add_logfile(
-                #     name=filename,
-                #     dir_path=os.path.dirname(get_dated_subdirectory_filepath(os.getcwd(), filename))
-                # )
-                print(
-                    self.main_window.file_viewer.model().filePath(
-                        self.main_window.file_viewer.selectionModel().currentIndex()
-                    )
+                filepath = self.main_window.file_viewer.model().filePath(
+                    self.main_window.file_viewer.selectionModel().currentIndex()
                 )
-            except Exception as e:
-                print(e)
+                self.log_service.add_logfile(
+                    name=filename,
+                    dir_path=filepath
+                )
+            except Exception as error_msg:
+                print(f'Failed to start logging to file {os.path.join(filepath, filename)}.\n{error_msg}')
 
             # Change button color and text
             self.main_window.logfile_status_button.setStyleSheet("background-color: red")

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -503,6 +503,7 @@ class Controller:
                 model.setRootPath(QtCore.QDir.rootPath())
                 self.main_window.file_viewer.setModel(model)
                 self.main_window.file_viewer.setRootIndex(model.index(QtCore.QDir.homePath()))
+                self.main_window.file_viewer.setColumnWidth(0, 200)
 
         else:
 

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -9,13 +9,14 @@ from io import StringIO
 import re
 from pylabnet.utils.logging.logger import LogService
 from PyQt5 import QtWidgets, QtGui, QtCore
+from datetime import datetime
 
 from pylabnet.utils.logging.logger import LogService
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.gui.pyqt.external_gui import Window
 from pylabnet.network.client_server.external_gui import Service, Client
 from pylabnet.utils.logging.logger import LogClient
-from pylabnet.utils.helper_methods import dict_to_str, remove_spaces, create_server, show_console, hide_console
+from pylabnet.utils.helper_methods import dict_to_str, remove_spaces, create_server, show_console, hide_console, get_dated_subdirectory_filepath
 
 
 if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
@@ -277,6 +278,7 @@ class Controller:
         self._configure_debug()
         self._configure_debug_combo_select()
         self._configure_logfile()
+        self._configure_logging()
 
         self.main_window.force_update()
 
@@ -485,7 +487,6 @@ class Controller:
     def _update_logfile_status(self):
         """ Updates the status of whether or not we are using a logfile """
         if self.main_window.log_file_button.isChecked():
-            self.log_file = True
             
             # Enable and show file browser
             self.main_window.file_viewer.setEnabled(True)
@@ -493,14 +494,16 @@ class Controller:
             self.main_window.logfile_status_button.setEnabled(True)
             self.main_window.logfile_status_button.setHidden(False)
             
-            # Assign a file system model
-            model = QtWidgets.QFileSystemModel()
-            model.setRootPath(QtCore.QDir.rootPath())
-            self.main_window.file_viewer.setModel(model)
-            self.main_window.file_viewer.setRootIndex(model.index(QtCore.QDir.homePath()))
+            # Assign a file system model if we're not already logging
+            if not self.main_window.logfile_status_button.isChecked():
+                model = QtWidgets.QFileSystemModel()
+                model.setRootPath(QtCore.QDir.rootPath())
+                self.main_window.file_viewer.setModel(model)
+                self.main_window.file_viewer.setRootIndex(model.index(QtCore.QDir.homePath()))
+                # selection_model = QtCore.QItemSelectionModel()
+                # self.main_window.file_viewer.setSelectionModel(selection_model)
 
         else:
-            self.log_file = False
 
             # Disable and hide file browser
             self.main_window.file_viewer.setHidden(True)
@@ -516,7 +519,37 @@ class Controller:
 
     def _start_stop_logging(self):
         """ Starts or stops logging to file depending on situation """
-        
+
+        if self.main_window.logfile_status_button.isChecked():
+
+            # Actually start logging
+            self.log_file = True
+            # filename = f'logfile_{datetime.now().strftime("%H_%M_%S")}'
+            try:
+                # self.log_service.add_logfile(
+                #     name=filename,
+                #     dir_path=os.path.dirname(get_dated_subdirectory_filepath(os.getcwd(), filename))
+                # )
+                print(
+                    self.main_window.file_viewer.model().filePath(
+                        self.main_window.file_viewer.selectionModel().currentIndex()
+                    )
+                )
+            except Exception as e:
+                print(e)
+
+            # Change button color and text
+            self.main_window.logfile_status_button.setStyleSheet("background-color: red")
+            self.main_window.logfile_status_button.setText('Stop logging to file')
+
+        else:
+
+            # Change button color and text
+            self.main_window.logfile_status_button.setStyleSheet("background-color: green")
+            self.main_window.logfile_status_button.setText('Start logging to file')
+
+            # Actually stop logging
+            self.log_file = False
 
 
 def main():

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -272,6 +272,7 @@ class Controller:
         self.main_window.debug_comboBox.setHidden(True)
         self.main_window.logfile_status_button.setHidden(True)
         self.main_window.log_previous.setHidden(True)
+        self.main_window.logfile_status_indicator.setEnabled(False)
 
         # Configure list of scripts to run and clicking actions
         self._load_scripts()
@@ -542,6 +543,7 @@ class Controller:
             # Change button color and text
             self.main_window.logfile_status_button.setStyleSheet("background-color: red")
             self.main_window.logfile_status_button.setText('Stop logging to file')
+            self.main_window.logfile_status_indicator.setChecked(True)
 
             # Add previous text to logfile
             if self.main_window.log_previous.isChecked():
@@ -555,6 +557,7 @@ class Controller:
             # Change button color and text
             self.main_window.logfile_status_button.setStyleSheet("background-color: green")
             self.main_window.logfile_status_button.setText('Start logging to file')
+            self.main_window.logfile_status_indicator.setChecked(False)
 
             # Actually stop logging
             self.log_service.stop_latest_logfile()

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -55,7 +55,6 @@ class Controller:
         self.disconnection = False
         self.debug = False
         self.debug_level = None
-        self.log_file = False
         try:
             if sys.argv[1] == '-p' or proxy:
                 self.proxy = True
@@ -268,9 +267,11 @@ class Controller:
 
         # Hide some buttons
         self.main_window.file_viewer.setHidden(True)
-        self.main_window.file_viewer.setEnabled(False)
         self.main_window.logfile_status_button.setHidden(True)
-        self.main_window.logfile_status_button.setEnabled(False)
+        self.main_window.debug_label.setHidden(True)
+        self.main_window.debug_comboBox.setHidden(True)
+        self.main_window.logfile_status_button.setHidden(True)
+        self.main_window.log_previous.setHidden(True)
 
         # Configure list of scripts to run and clicking actions
         self._load_scripts()
@@ -493,6 +494,8 @@ class Controller:
             self.main_window.file_viewer.setHidden(False)
             self.main_window.logfile_status_button.setEnabled(True)
             self.main_window.logfile_status_button.setHidden(False)
+            self.main_window.log_previous.setEnabled(True)
+            self.main_window.log_previous.setHidden(False)
             
             # Assign a file system model if we're not already logging
             if not self.main_window.logfile_status_button.isChecked():
@@ -508,6 +511,8 @@ class Controller:
             self.main_window.file_viewer.setEnabled(False)
             self.main_window.logfile_status_button.setHidden(True)
             self.main_window.logfile_status_button.setEnabled(False)
+            self.main_window.log_previous.setEnabled(False)
+            self.main_window.log_previous.setHidden(True)
 
     def _update_debug_level(self, i=0):
         # Set debug level according to combo-box selection.
@@ -521,7 +526,6 @@ class Controller:
         if self.main_window.logfile_status_button.isChecked():
 
             # Actually start logging
-            self.log_file = True
             filename = f'logfile_{datetime.now().strftime("%H_%M_%S")}'
             try:
                 filepath = self.main_window.file_viewer.model().filePath(
@@ -538,6 +542,13 @@ class Controller:
             self.main_window.logfile_status_button.setStyleSheet("background-color: red")
             self.main_window.logfile_status_button.setText('Stop logging to file')
 
+            # Add previous text to logfile
+            if self.main_window.log_previous.isChecked():
+                self.log_service.logger.info(
+                    f'Previous log terminal content: \n{self.main_window.terminal.toPlainText()}'
+                    f'\n---------------------------'
+                )
+
         else:
 
             # Change button color and text
@@ -545,7 +556,7 @@ class Controller:
             self.main_window.logfile_status_button.setText('Start logging to file')
 
             # Actually stop logging
-            self.log_file = False
+            self.log_service.stop_latest_logfile()
 
 
 def main():

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -54,6 +54,7 @@ class Controller:
         self.disconnection = False
         self.debug = False
         self.debug_level = None
+        self.log_file = False
         try:
             if sys.argv[1] == '-p' or proxy:
                 self.proxy = True
@@ -264,11 +265,18 @@ class Controller:
         self.main_window.assign_label('buffer_terminal', 'buffer')
         self.main_window.assign_event_button('debug_radio_button', 'debug')
 
+        # Hide some buttons
+        self.main_window.file_viewer.setHidden(True)
+        self.main_window.file_viewer.setEnabled(False)
+        self.main_window.logfile_status_button.setHidden(True)
+        self.main_window.logfile_status_button.setEnabled(False)
+
         # Configure list of scripts to run and clicking actions
         self._load_scripts()
         self._configure_clicks()
         self._configure_debug()
         self._configure_debug_combo_select()
+        self._configure_logfile()
 
         self.main_window.force_update()
 
@@ -443,6 +451,14 @@ class Controller:
     def _configure_debug(self):
         self.main_window.debug_radio_button.toggled.connect(self._update_debug_settings)
 
+    def _configure_logging(self):
+        """ Defines what to do if the Start/Stop Logging button is clicked """
+        self.main_window.logfile_status_button.toggled.connect(self._start_stop_logging)
+
+    def _configure_logfile(self):
+        """ Defines what to do if the logfile radio button is clicked """
+        self.main_window.log_file_button.toggled.connect(self._update_logfile_status)
+    
     # Defines what to do if combobox is changed.
     def _configure_debug_combo_select(self):
         self.main_window.debug_comboBox.currentIndexChanged.connect(self._update_debug_level)
@@ -464,13 +480,43 @@ class Controller:
             self.main_window.debug_comboBox.setHidden(True)
 
         # Update debug level.
-        self._update_debug_level(self)
+        self._update_debug_level()
+
+    def _update_logfile_status(self):
+        """ Updates the status of whether or not we are using a logfile """
+        if self.main_window.log_file_button.isChecked():
+            self.log_file = True
+            
+            # Enable and show file browser
+            self.main_window.file_viewer.setEnabled(True)
+            self.main_window.file_viewer.setHidden(False)
+            self.main_window.logfile_status_button.setEnabled(True)
+            self.main_window.logfile_status_button.setHidden(False)
+            
+            # Assign a file system model
+            model = QtWidgets.QFileSystemModel()
+            model.setRootPath(QtCore.QDir.rootPath())
+            self.main_window.file_viewer.setModel(model)
+            self.main_window.file_viewer.setRootIndex(model.index(QtCore.QDir.homePath()))
+
+        else:
+            self.log_file = False
+
+            # Disable and hide file browser
+            self.main_window.file_viewer.setHidden(True)
+            self.main_window.file_viewer.setEnabled(False)
+            self.main_window.logfile_status_button.setHidden(True)
+            self.main_window.logfile_status_button.setEnabled(False)
 
     def _update_debug_level(self, i=0):
         # Set debug level according to combo-box selection.
         # Levels are:
         # pylabnet_server, pylabnet_gui, launcher
         self.debug_level = self.main_window.debug_comboBox.currentText()
+
+    def _start_stop_logging(self):
+        """ Starts or stops logging to file depending on situation """
+        
 
 
 def main():

--- a/pylabnet/utils/helper_methods.py
+++ b/pylabnet/utils/helper_methods.py
@@ -124,11 +124,11 @@ def slugify(value, allow_unicode=False):
     return re.sub(r'[-\s]+', '-', value)
 
 
-def get_dated_subdirectory_filepath(directory, filename):
+def get_dated_subdirectory_filepath(directory, filename=None):
     '''Creates directory structure folder_path/YEAR/MONTH/DAY/filename
 
     :folder_path: Upper level directory
-    :filename: Name of file. Will be slugified.
+    :filename: Name of file. Will be slugified. If None just returns directory
 
     Return:
     :filepath: Path to file in newly created structure.
@@ -141,7 +141,10 @@ def get_dated_subdirectory_filepath(directory, filename):
     os.makedirs(dated_path, exist_ok=True)
 
     # Define full file path
-    filepath = os.path.join(dated_path, f'{slugify(filename)}.log')
+    if filename is None:
+        filepath = dated_path
+    else:
+        filepath = os.path.join(dated_path, f'{slugify(filename)}')
 
     return filepath
 

--- a/pylabnet/utils/logging/logger.py
+++ b/pylabnet/utils/logging/logger.py
@@ -388,3 +388,4 @@ class LogService(rpyc.Service):
                 module_name
             ))
 
+    # TODO: implement switching to log-file

--- a/pylabnet/utils/logging/logger.py
+++ b/pylabnet/utils/logging/logger.py
@@ -410,3 +410,7 @@ class LogService(rpyc.Service):
         # add fh to logger
         self.logger.addHandler(fh)
 
+    def stop_latest_logfile(self):
+        """ Stops the latest logfile """
+
+        self.logger.removeHandler(self.logger.handlers[-1])

--- a/pylabnet/utils/logging/logger.py
+++ b/pylabnet/utils/logging/logger.py
@@ -388,7 +388,7 @@ class LogService(rpyc.Service):
                 module_name
             ))
 
-    def add_logfile(self, name, dir_path, file_level=logging.debug, form_string=None):
+    def add_logfile(self, name, dir_path, file_level=logging.DEBUG, form_string=None):
         """ Adds a log-file for all future logging
 
         :name: Name of the log-file.

--- a/pylabnet/utils/logging/logger.py
+++ b/pylabnet/utils/logging/logger.py
@@ -388,4 +388,25 @@ class LogService(rpyc.Service):
                 module_name
             ))
 
-    # TODO: implement switching to log-file
+    def add_logfile(self, name, dir_path, file_level=logging.debug, form_string=None):
+        """ Adds a log-file for all future logging
+
+        :name: Name of the log-file.
+        :dir_path: Directory where the log files will be generated.
+        :file_level: The minimum message level which appears in the log-file.
+        :form_string: String specifying the output format of the logger. If None, default styling is:
+            "%(asctime)s - %(levelname)s - %(message)s"
+        """
+
+        formatting_string = '%(asctime)s - %(levelname)s - %(message)s' or form_string
+        formatter = logging.Formatter(formatting_string)
+        filename = get_dated_subdirectory_filepath(dir_path, name)
+        fh = logging.FileHandler(filename)
+        fh.setLevel(file_level)
+
+        # add formatter to fh
+        fh.setFormatter(formatter)
+
+        # add fh to logger
+        self.logger.addHandler(fh)
+


### PR DESCRIPTION
Added functionality for selecting and initializing file storage of logs from Launch control GUI.

By default, the logging software works as usual, but the user now has the option to select a new radio button `Log File`

![image](https://user-images.githubusercontent.com/38106879/87675704-b6b1d500-c745-11ea-8985-05bc47ab3ad4.png)

When selected, a `QTreeView` widget formatted as a file browser enables selection of a directory for storing the log-file

![image](https://user-images.githubusercontent.com/38106879/87675945-009abb00-c746-11ea-80b1-e94ff94b8f72.png)

The user can then navigate this browser and select an appropriate directory. Additionally, if the user wants to log all previous information that was already in the GUI terminal, the `Log Previous` radio button can be selected.

![image](https://user-images.githubusercontent.com/38106879/87676076-288a1e80-c746-11ea-8c90-180b602c0c96.png)

When the green `Start logging to file` button is pressed, the logfile is created in a dated subdirectory within the highlighted path. A new `FileHandler` is added to the running `log_service`, storing all new log information in a timestamped file named: `logfile_%H_%M_%S`. If the `Log Previous` button was selected, the previous terminal information is duplicated into the terminal and this file.

![image](https://user-images.githubusercontent.com/38106879/87676633-d695c880-c746-11ea-850d-8a7f5d159acd.png)

The red button can be pressed to stop the file logging, which removes the filehandler, and resets to the original green button state

![image](https://user-images.githubusercontent.com/38106879/87676788-08a72a80-c747-11ea-97cb-7f95c99428c8.png)

If the green button is clicked again, this will produce a new logfile with a new timestamp.