### PR TITLE
leak-valve

### DIFF
--- a/demo/NI_cDaq/leak_valve_client.ipynb
+++ b/demo/NI_cDaq/leak_valve_client.ipynb
@@ -1,0 +1,79 @@
+{
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.3-final"
+  },
+  "orig_nbformat": 2,
+  "kernelspec": {
+   "name": "python_defaultSpec_1599687956966",
+   "display_name": "Python 3.8.3 64-bit ('dev': venv)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2,
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pylabnet.utils.logging.logger import LogClient\n",
+    "from pylabnet.network.client_server.nidaqmx_card import Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leak_client = LogClient(\n",
+    "    host='140.247.189.169',\n",
+    "    port=33810,\n",
+    "    module_tag='leak_valve_client'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valve = Client(\n",
+    "    host='140.247.189.169',\n",
+    "    port=42194\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valve.set_ao_voltage(\n",
+    "    ao_channel='ao0',\n",
+    "    voltages=0\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ]
+}

--- a/pylabnet/launchers/servers/nidaqmx_leakvalve.py
+++ b/pylabnet/launchers/servers/nidaqmx_leakvalve.py
@@ -1,0 +1,42 @@
+""" Implements connection and server launching of NI-daqMX card for wavemeter locking"""
+
+import socket
+
+from pylabnet.hardware.ni_daqs import nidaqmx_card
+from pylabnet.network.client_server.nidaqmx_card import Service, Client
+from pylabnet.network.core.generic_server import GenericServer
+
+# Parameters
+NI_DEVICE_NAME = 'Dev1'
+
+
+def launch(**kwargs):
+    """ Connects to NI-daqMX card and launches server
+
+    :param kwargs: (dict) containing relevant kwargs
+        :logger: instance of LogClient for logging purposes
+        :port: (int) port number for the Cnt Monitor server
+    """
+
+    # Instantiate driver
+    ni_daqmx_logger = kwargs['logger']
+    try:
+        ni_driver = nidaqmx_card.Driver(
+            device_name=NI_DEVICE_NAME,
+            logger=ni_daqmx_logger
+        )
+    except OSError:
+        ni_daqmx_logger.error(f'Did not find NI daqMX name {NI_DEVICE_NAME}')
+        raise
+
+    # Instantiate server
+    ni_daqmx_service = Service()
+    ni_daqmx_service.assign_module(module=ni_driver)
+    ni_daqmx_service.assign_logger(logger=ni_daqmx_logger)
+    ni_daqmx_server = GenericServer(
+        service=ni_daqmx_service,
+        host=socket.gethostbyname(socket.gethostname()),
+        port=kwargs['port']
+    )
+
+    ni_daqmx_server.start()


### PR DESCRIPTION
Minor update including a launcher for connecting to NI-USB and starting a server to enable setting of leak-valve voltages.

New module: `pylabnet.network.launchers.servers.nidaqmx_leakvalve`
Demo notebook for client: `demo/NI_cDaq/leak_valve_client.ipynb`