### PR TITLE
Dummy devices

### DIFF
--- a/demo/zihdawg/HDAWG_example.ipynb
+++ b/demo/zihdawg/HDAWG_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,23 +18,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dev_id = 'dev8040'\n",
+    "dev_id = 'dev8227'\n",
     "\n",
     "# Instantiate\n",
     "logger = LogClient(\n",
-    "    host='localhost',\n",
-    "    port=14785,\n",
+    "    host='140.247.189.94',\n",
+    "    port=19959,\n",
     "    module_tag=f'ZI HDAWG {dev_id}'\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +352,40 @@
    "execution_count": 4,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Dummy device setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hd = Driver(dev_id, logger, dummy=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "AttributeError",
+     "evalue": "'Driver' object has no attribute 'daq'",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-4-0dff95fd5186>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mhd\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdisable_everything\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m~\\pylabnet\\pylabnet\\hardware\\awg\\zi_hdawg.py\u001b[0m in \u001b[0;36mdisable_everything\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     48\u001b[0m         \u001b[0mDisable\u001b[0m \u001b[0mall\u001b[0m \u001b[0mavailable\u001b[0m \u001b[0moutputs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mawgs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mdemods\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mscopes\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0metc\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     49\u001b[0m         \"\"\"\n\u001b[1;32m---> 50\u001b[1;33m         \u001b[0mzhinst\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdisable_everything\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdaq\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdevice_id\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     51\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Disabled everything.\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     52\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mAttributeError\u001b[0m: 'Driver' object has no attribute 'daq'"
+     ]
+    }
+   ],
+   "source": [
+    "hd.disable_everything()"
+   ]
   },
   {
    "cell_type": "code",
@@ -378,7 +411,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.6.5-final"
   }
  },
  "nbformat": 4,

--- a/demo/zihdawg/HDAWG_example.ipynb
+++ b/demo/zihdawg/HDAWG_example.ipynb
@@ -367,22 +367,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "error",
-     "ename": "AttributeError",
-     "evalue": "'Driver' object has no attribute 'daq'",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-4-0dff95fd5186>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mhd\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdisable_everything\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[1;32m~\\pylabnet\\pylabnet\\hardware\\awg\\zi_hdawg.py\u001b[0m in \u001b[0;36mdisable_everything\u001b[1;34m(self)\u001b[0m\n\u001b[0;32m     48\u001b[0m         \u001b[0mDisable\u001b[0m \u001b[0mall\u001b[0m \u001b[0mavailable\u001b[0m \u001b[0moutputs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mawgs\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mdemods\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mscopes\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0metc\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     49\u001b[0m         \"\"\"\n\u001b[1;32m---> 50\u001b[1;33m         \u001b[0mzhinst\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdisable_everything\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdaq\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdevice_id\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     51\u001b[0m         \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mlog\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"Disabled everything.\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     52\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mAttributeError\u001b[0m: 'Driver' object has no attribute 'daq'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "hd.disable_everything()"
    ]

--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -14,6 +14,8 @@ import copy
 from pylabnet.utils.logging.logger import LogHandler
 
 from pylabnet.utils.decorators.logging_redirector import log_standard_output
+from pylabnet.utils.decorators.dummy_wrapper import dummy_wrap
+
 
 # Storing the sampling rates and the corresponding target integers for the setInt command
 SAMPLING_RATE_DICT = {
@@ -36,11 +38,13 @@ SAMPLING_RATE_DICT = {
 
 class Driver():
 
+    @dummy_wrap
     def reset_DIO_outputs(self):
         """Sets all DIO outputs to low"""
         self.seti('dios/0/output', 0)
         self.log.info("Set all DIO outputs to low.")
 
+    @dummy_wrap
     def disable_everything(self):
         """ Create a base configuration.
         Disable all available outputs, awgs, demods, scopes, etc.
@@ -49,6 +53,7 @@ class Driver():
         self.log.info("Disabled everything.")
 
     @log_standard_output
+    @dummy_wrap
     def log_stdout(self, function):
         """ Execute function and log print output to self.log
 
@@ -64,30 +69,13 @@ class Driver():
             input_argument = [input_argument]
         return input_argument
 
-    def __init__(self, device_id, logger, api_level=6):
-        """ Instantiate AWG
-
-        :logger: instance of LogClient class
-        :device_id: Device id of connceted ZI HDAWG, for example 'dev8060'
-        :api_level: API level of zhins API
-        """
-
-        # Instantiate log
-        self.log = LogHandler(logger=logger)
-
-        # Part of this code has been modified from
-        # ZI's Zurich Instruments LabOne Python API Example
-
-        # Call a zhinst utility function that returns:
-        # - an API session `daq` in order to communicate
-        # with devices via the data server.
-        # - the device ID string that specifies the device
-        # branch in the server's node hierarchy.
-        # - the device's discovery properties.
+    @dummy_wrap
+    def _setup_hdawg(self, device_id, logger, api_level):
+        ''' Sets up HDAWG '''
 
         err_msg = "This example can only be run on an HDAWG."
 
-        # Connect to device and log print output, not the lambda expression.
+          # Connect to device and log print output, not the lambda expression.
         (daq, device, props) = self.log_stdout(
             lambda: zhinst.utils.create_api_session(
                 device_id,
@@ -111,7 +99,26 @@ class Driver():
             re.compile('HDAWG(4|8{1})').match(props['devicetype']).group(1)
         )
 
+    def __init__(self, device_id, logger, dummy=False, api_level=6):
+        """ Instantiate AWG
+
+        :logger: instance of LogClient class
+        :device_id: Device id of connceted ZI HDAWG, for example 'dev8060'
+        :api_level: API level of zhins API
+        """
+
+        # Instantiate log
+        self.log = LogHandler(logger=logger)
+
+        # Store dummy flag
+        self.dummy = dummy
+
+        # Setup HDAWG
+        self._setup_hdawg(device_id, logger, api_level)
+
+
     @log_standard_output
+    @dummy_wrap
     def seti(self, node, new_int):
         """
         Warapper for daq.setInt commands. For instance, instead of
@@ -126,6 +133,7 @@ class Driver():
         self.daq.setInt(f'/{self.device_id}/{node}', new_int)
 
     @log_standard_output
+    @dummy_wrap
     def setd(self, node, new_double):
         """
         Warapper for daq.setDouble commands. For instance, instead of
@@ -140,6 +148,7 @@ class Driver():
         self.daq.setDouble(f'/{self.device_id}/{node}', new_double)
 
     @log_standard_output
+    @dummy_wrap
     def setv(self, node, vector):
         """
         Warapper for daq.setVector commands. For instance, instead of
@@ -154,6 +163,7 @@ class Driver():
         self.daq.setVector(f'/{self.device_id}/{node}', vector)
 
     @log_standard_output
+    @dummy_wrap
     def geti(self, node):
         """
         Warapper for daq.getInt commands. For instance, instead of
@@ -166,6 +176,7 @@ class Driver():
 
         return self.daq.getInt(f'/{self.device_id}/{node}')
 
+    @dummy_wrap
     def set_channel_grouping(self, index):
         """ Specifies channel grouping.
 
@@ -179,6 +190,7 @@ class Driver():
 
     # Functions related to wave outputs:
 
+    @dummy_wrap
     def _toggle_output(self, output_indices, target_index):
         """
         Local function enabeling/disabeling wave output.
@@ -200,6 +212,7 @@ class Driver():
                         channel index {output_index} is invalid."
                 )
 
+    @dummy_wrap
     def enable_output(self, output_indices):
         """
         Enables wave output.
@@ -213,6 +226,7 @@ class Driver():
 
         self._toggle_output(output_indices, 1)
 
+    @dummy_wrap
     def disable_output(self, output_indices):
         """
         Disables wave output.
@@ -222,6 +236,7 @@ class Driver():
         """
         self._toggle_output(output_indices, 0)
 
+    @dummy_wrap
     def set_output_range(self, output_index, output_range):
         """
         Set the output range.

--- a/pylabnet/utils/decorators/decorator_utils.py
+++ b/pylabnet/utils/decorators/decorator_utils.py
@@ -9,3 +9,4 @@ def get_signature(*args, **kwargs):
     kwargs_repr = [f"{k}={v!r}" for k, v in kwargs.items()]
     signature = ", ".join(args_repr + kwargs_repr)
     return signature
+

--- a/pylabnet/utils/decorators/dummy_wrapper.py
+++ b/pylabnet/utils/decorators/dummy_wrapper.py
@@ -1,0 +1,25 @@
+
+from .decorator_utils import get_signature
+import functools
+
+
+
+def dummy_wrap(func):
+    """ Decorator which re-routed functions of Driver() objects
+    to only produce logged outputs, if the dummy flas ist set.
+
+    This will enable to use of dummy-versions of drivers.
+    """
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+
+        # If in dummy mode, log which function is executed.
+        if self.dummy:
+            function_name = func.__name__
+            self.log.info(f'Dummy execution of {function_name}')
+        # If not in dummy mode, execute function.
+        else:
+            # Execute function.
+            return func(self, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
This branch implements a decorator, which can transform any hardware`Driver()` class to a dummy version of said class. Using the `dummy=True` flag, and setting a `@dummy_wrap` decorator to all functions that should be accessible in the dummy mode, it is possible to work with driver objects without connecting it to hardware. 

# Example

Using a hdawg driver looks like this:

```python
hd = Driver(dev_id, logger)
hd.disable_everything() # Disables all wave outputs
```

Now, by making a minor adjustment to the `__init__` function  of the driver, and by decorating all member functions with the `@dummy_wrap` wrapper:

```python
    def __init__(self, device_id, logger, dummy=False, api_level=6):
        """ Instantiate AWG

        :logger: instance of LogClient class
        :device_id: Device id of connceted ZI HDAWG, for example 'dev8060'
        :api_level: API level of zhins API
        """

        # Instantiate log
        self.log = LogHandler(logger=logger)

        # Store dummy flag
        self.dummy = dummy

        # Setup HDAWG
        self._setup_hdawg(device_id, logger, api_level)

@dummy_wrap
    def _setup_hdawg(self, device_id, logger, api_level):
        # The actual setup code.

@dummy_wrap
    def any_other_function(self, ...):
        # Function.
```

, the following lines can be executed without being connected to actual hardware:

```python
hd = Driver(dev_id, logger, dummy=True)
hd.disable_everything() # Does nothing, logs attempted function execution.
```

Looking at the logger confirms the execution of the dummy function:
![image](https://user-images.githubusercontent.com/4958226/94171413-3bfce880-fe5f-11ea-8199-4a6d240d5b05.png)


This dummy decorator effectively allows for the quick transformation of an actual `Driver()` object to a dummy version of it, while keeping all member functions available. 