### PR TITLE
B16 laserscans + script service functionality

### DIFF
--- a/pylabnet/hardware/ni_daqs/nidaqmx_card.py
+++ b/pylabnet/hardware/ni_daqs/nidaqmx_card.py
@@ -124,8 +124,8 @@ class Driver:
         # Create counter task and assign parameters
         self.counters[name] = TimedCounter(
             logger=self.log,
-            counter_channel=counter_channel,
-            physical_channel=physical_channel
+            counter_channel=self._gen_ch_path(counter_channel),
+            physical_channel='/'+self._gen_ch_path(physical_channel)
         )
         self.counters[name].set_parameters(duration)
 
@@ -201,7 +201,7 @@ class TimedCounter:
 
         # Create a task - note we have to be careful and close the task if something goes wrong
         self.task = None
-        self.activate_task(counter_channel, physical_channel='/Dev1/20MHzTimebase')
+        self.activate_task(counter_channel, physical_channel=physical_channel)
 
     def activate_task(self, counter_channel='Dev1/ctr0', physical_channel='/Dev1/20MHzTimebase'):
         """ Activates task. Must be used to restart counting if the close command is called """

--- a/pylabnet/scripts/lasers/wlm_monitor.py
+++ b/pylabnet/scripts/lasers/wlm_monitor.py
@@ -764,8 +764,6 @@ def launch(**kwargs):
     channel_params = [p for p in config['channels'].values()]
     params = dict(channel_params=channel_params)
 
-    # gui_client = guis['wavemeter_monitor']
-
     # Instantiate Monitor script
     wlm_monitor = WlmMonitor(
         wlm_client=wavemeter_client,
@@ -774,15 +772,10 @@ def launch(**kwargs):
         params=params
     )
 
-    update_service = Service()
+    update_service = kwargs['service']
     update_service.assign_module(module=wlm_monitor)
-    update_service.assign_logger(logger=logger)
-    update_server, update_port = create_server(update_service, logger, host=socket.gethostbyname_ex(socket.gethostname())[2][0])
-    logger.update_data(data={'port': update_port})
     logger.update_data(data=dict(device_id=device_id))
-    logger.info('Created WLM update port')
-    wlm_monitor.gui.set_network_info(port=update_port)
-    update_server.start()
+    wlm_monitor.gui.set_network_info(port=kwargs['server_port'])
 
     # Run continuously
     # Note that the actual operation inside run() can be paused using the update server

--- a/pylabnet/scripts/sweeper/scan_1d.py
+++ b/pylabnet/scripts/sweeper/scan_1d.py
@@ -446,13 +446,10 @@ def launch(**kwargs):
         config=kwargs['config'],
     )
 
-    update_service = Service()
+    update_service = kwargs['service']
     update_service.assign_module(module=control)
-    update_service.assign_logger(logger=logger)
-    update_server, update_port = create_server(update_service, logger, host=socket.gethostbyname_ex(socket.gethostname())[2][0])
-    logger.update_data(data={'port': update_port})
+    update_port = kwargs['server_port']
     control.gui.set_network_info(port=update_port)
-    update_server.start()
 
     # Run continuously
     # Note that the actual operation inside run() can be paused using the update server


### PR DESCRIPTION
Implemented and tested laser scanning using wavemeter and nidaqmx counter in B16.

## Specific upgrades
- Fixed a bug in the nidaqmx `TimedCounter` subclass to allow for using arbitrary physical counter channels
- Tested counter functionality from full `scan_1d` script

## Generic upgrade: script service capability from launcher

Can now launch a script and tie the script server to a script-specific service that can implement remote functions on the script. If a custom `Service` is implemented in the `pylabnet.scripts.my_script` module, just pass the `"script_service" : "True"` flag in the script config file, and `pylabnet.scripts.my_script.Service` will be instantiated and used as the basis for the script server, rather than the `ServiceBase` class. This is useful e.g. in the wavemeter locking software to use the server for access to script parameters such as wavemeter setpoint.

This closes issue #161 