### PR TITLE
IP bugfix

### DIFF
--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -21,7 +21,7 @@ from pylabnet.gui.pyqt.external_gui import Window
 from pylabnet.network.client_server.external_gui import Service, Client
 from pylabnet.utils.logging.logger import LogClient
 from pylabnet.launchers.launcher import Launcher
-from pylabnet.utils.helper_methods import dict_to_str, remove_spaces, create_server, show_console, hide_console, get_dated_subdirectory_filepath, get_config_directory, load_device_config, launch_device_server, launch_script
+from pylabnet.utils.helper_methods import dict_to_str, remove_spaces, create_server, show_console, hide_console, get_dated_subdirectory_filepath, get_config_directory, load_device_config, launch_device_server, launch_script, get_ip
 
 
 if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
@@ -94,7 +94,7 @@ class Controller:
                 self.proxy = True
             else:
                 self.proxy = False
-        self.host = socket.gethostbyname_ex(socket.gethostname())[2][0]
+        self.host = get_ip()
         self.update_index = 0
 
         # Find logger if applicable
@@ -161,7 +161,7 @@ class Controller:
                 self.gui_server, self.gui_port = create_server(
                     self.gui_service,
                     logger=self.gui_logger,
-                    host=socket.gethostbyname_ex(socket.gethostname())[2][0]
+                    host=get_ip()
                     )
             else:
                 try:
@@ -256,7 +256,7 @@ class Controller:
         if self.LOG_PORT is None:
             self.log_server, self.log_port = create_server(
                 self.log_service,
-                host=socket.gethostbyname_ex(socket.gethostname())[2][0]
+                host=get_ip()
                 )
         else:
             try:
@@ -281,7 +281,7 @@ class Controller:
         if self.proxy:
             self.main_window.setWindowTitle('Launch Control (Proxy)')
             ip_str = 'Master (Local) '
-            ip_str_2 = f' ({socket.gethostbyname_ex(socket.gethostname())[2][0]})'
+            ip_str_2 = f' ({get_ip()})'
             log_str = 'Master '
         self.main_window.ip_label.setText(
             f'{ip_str}IP Address: {self.host}'+ip_str_2

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -49,7 +49,7 @@ import os
 import socket
 import importlib.util
 from pylabnet.utils.logging import logger
-from pylabnet.utils.helper_methods import parse_args, show_console, hide_console, create_server, load_config, load_script_config, load_device_config, launch_device_server
+from pylabnet.utils.helper_methods import get_ip, parse_args, show_console, hide_console, create_server, load_config, load_script_config, load_device_config, launch_device_server
 from pylabnet.network.client_server import external_gui
 from pylabnet.network.core.service_base import ServiceBase
 from pylabnet.network.core.generic_server import GenericServer
@@ -379,7 +379,7 @@ class Launcher:
         self.script_server, self.script_server_port = create_server(
             service=self.service,
             logger=self.logger,
-            host=socket.gethostbyname_ex(socket.gethostname())[2][0]
+            host=get_ip()
         )
         self.script_server.start()
 

--- a/pylabnet/launchers/pylabnet_gui.py
+++ b/pylabnet/launchers/pylabnet_gui.py
@@ -24,7 +24,7 @@ from pylabnet.gui.pyqt.external_gui import Window
 from pylabnet.network.client_server.external_gui import Service
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.utils.logging.logger import LogClient
-from pylabnet.utils.helper_methods import parse_args, show_console, hide_console, create_server, load_config
+from pylabnet.utils.helper_methods import get_ip, parse_args, show_console, hide_console, create_server, load_config
 
 import sys
 import socket
@@ -142,18 +142,18 @@ def main():
             gui_server, gui_port = create_server(
                 service=gui_service,
                 logger=gui_logger,
-                host=socket.gethostbyname_ex(socket.gethostname())[2][0]
+                host=get_ip()
             )
             gui_logger.update_data(data=dict(port=gui_port))
         else:
             gui_server = GenericServer(
                 service=gui_service,
-                host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+                host=get_ip(),
                 port=gui_port
             )
     except ConnectionRefusedError:
         gui_logger.warn('Tried and failed to create GUI server with \nIP:{}\nPort:{}'.format(
-            socket.gethostbyname_ex(socket.gethostname())[2][0],
+            get_ip(),
             gui_port
         ))
         raise
@@ -162,7 +162,7 @@ def main():
     # Update GUI with server-specific details
     try:
         main_window.ip_label.setText('IP Address: {}'.format(
-            socket.gethostbyname_ex(socket.gethostname())[2][0]
+            get_ip()
         ))
         main_window.port_label.setText('Port: {}'.format(gui_port))
     except AttributeError:

--- a/pylabnet/launchers/servers/aom_toptica.py
+++ b/pylabnet/launchers/servers/aom_toptica.py
@@ -4,6 +4,7 @@ import socket
 
 import pylabnet.hardware.awg.zi_hdawg as zi_hdawg
 from pylabnet.network.client_server.staticline import Service, Client
+from pylabnet.utils.helper_methods import get_ip
 
 import pylabnet.hardware.staticline.staticline as staticline
 
@@ -41,7 +42,7 @@ def launch(**kwargs):
     staticline_service.assign_logger(logger=staticline_logger)
     staticline_service_server = GenericServer(
         service=staticline_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/dio_breakout.py
+++ b/pylabnet/launchers/servers/dio_breakout.py
@@ -1,7 +1,7 @@
 from pyvisa import ResourceManager, VisaIOError
 import socket
 from pylabnet.hardware.awg.dio_breakout import Driver
-from pylabnet.utils.helper_methods import show_console, hide_console, load_device_config
+from pylabnet.utils.helper_methods import get_ip, show_console, hide_console, load_device_config
 from pylabnet.network.client_server.dio_breakout import Service, Client
 from pylabnet.network.core.generic_server import GenericServer
 
@@ -42,7 +42,7 @@ def launch(**kwargs):
     dio_service.assign_logger(logger=kwargs['logger'])
     dio_server = GenericServer(
         service=dio_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
     dio_server.start()

--- a/pylabnet/launchers/servers/dummy.py
+++ b/pylabnet/launchers/servers/dummy.py
@@ -1,4 +1,4 @@
-from pylabnet.utils.helper_methods import load_device_config
+from pylabnet.utils.helper_methods import load_device_config, get_ip
 from pylabnet.network.core.service_base import ServiceBase
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.core.client_base import ClientBase
@@ -20,8 +20,8 @@ def launch(**kwargs):
     log = kwargs['logger']
     log.info(f'Launching with config {kwargs["config"]}')
     config = load_device_config(
-        os.path.basename(__file__)[:-3], 
-        kwargs['config'], 
+        os.path.basename(__file__)[:-3],
+        kwargs['config'],
         log
     )
 
@@ -32,7 +32,7 @@ def launch(**kwargs):
     dum_service.assign_logger(logger=log)
     dum_server = GenericServer(
         service=dum_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
     dum_server.start()

--- a/pylabnet/launchers/servers/external_gui.py
+++ b/pylabnet/launchers/servers/external_gui.py
@@ -8,7 +8,7 @@ from PyQt5 import QtWidgets, uic, QtCore, QtGui
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.client_server.external_gui import Service, Client
 from pylabnet.gui.pyqt.external_gui import Window
-from pylabnet.utils.helper_methods import show_console, hide_console, create_server
+from pylabnet.utils.helper_methods import get_ip, show_console, hide_console, create_server
 
 # Should help with scaling issues on monitors of differing resolution
 if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
@@ -50,12 +50,12 @@ def launch(logger=None, port=None, name=None):
         gui_server, port = create_server(
             service=gui_service,
             logger=logger,
-            host=socket.gethostbyname_ex(socket.gethostname())[2][0]
+            host=get_ip()
         )
     else:
         gui_server = GenericServer(
             service=gui_service,
-            host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+            host=get_ip(),
             port=port
         )
     logger.update_data(data=dict(ui=ui, port=port))
@@ -64,7 +64,7 @@ def launch(logger=None, port=None, name=None):
 
     # Update GUI with server-specific details
     main_window.ip_label.setText('IP Address: {}'.format(
-        socket.gethostbyname_ex(socket.gethostname())[2][0]
+        get_ip()
     ))
     main_window.port_label.setText('Port: {}'.format(port))
 

--- a/pylabnet/launchers/servers/green_imaging_laser.py
+++ b/pylabnet/launchers/servers/green_imaging_laser.py
@@ -4,6 +4,7 @@ import socket
 
 import pylabnet.hardware.ni_daqs.nidaqmx_card as nidaqmx
 import pylabnet.hardware.staticline.staticline as staticline
+from pylabnet.utils.helper_methods import get_ip
 
 from pylabnet.network.client_server.staticline import Service, Client
 
@@ -40,7 +41,7 @@ def launch(**kwargs):
     staticline_service.assign_logger(logger=staticline_logger)
     staticline_service_server = GenericServer(
         service=staticline_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/high_finesse_ws7.py
+++ b/pylabnet/launchers/servers/high_finesse_ws7.py
@@ -3,6 +3,7 @@ import socket
 from pylabnet.hardware.wavemeter.high_finesse_ws7 import Driver
 from pylabnet.network.client_server.high_finesse_ws7 import Service, Client
 from pylabnet.network.core.generic_server import GenericServer
+from pylabnet.utils.helper_methods import get_ip
 
 
 def launch(**kwargs):
@@ -25,7 +26,7 @@ def launch(**kwargs):
     wavemeter_service.assign_logger(logger=wavemeter_logger)
     wavemeter_server = GenericServer(
         service=wavemeter_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/mcs2.py
+++ b/pylabnet/launchers/servers/mcs2.py
@@ -4,6 +4,7 @@ import sys
 from pylabnet.hardware.nanopositioners.smaract import MCS2
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.client_server.smaract_mcs2 import Service, Client
+from pylabnet.utils.helper_methods import get_ip
 
 
 def launch(**kwargs):
@@ -20,7 +21,7 @@ def launch(**kwargs):
     mcs2_service.assign_logger(logger=kwargs['logger'])
     mcs2_server = GenericServer(
         service=mcs2_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
     mcs2_server.start()

--- a/pylabnet/launchers/servers/nidaqmx.py
+++ b/pylabnet/launchers/servers/nidaqmx.py
@@ -6,7 +6,7 @@ import os
 from pylabnet.hardware.ni_daqs import nidaqmx_card
 from pylabnet.network.client_server.nidaqmx_card import Service, Client
 from pylabnet.network.core.generic_server import GenericServer
-from pylabnet.utils.helper_methods import show_console, hide_console, load_config
+from pylabnet.utils.helper_methods import get_ip, show_console, hide_console, load_config
 
 
 
@@ -69,7 +69,7 @@ def launch(**kwargs):
     ni_daqmx_service.assign_logger(logger=ni_daqmx_logger)
     ni_daqmx_server = GenericServer(
         service=ni_daqmx_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/nidaqmx_ai.py
+++ b/pylabnet/launchers/servers/nidaqmx_ai.py
@@ -6,7 +6,7 @@ import os
 from pylabnet.hardware.ni_daqs import nidaqmx_card
 from pylabnet.network.client_server.nidaqmx_card import Service, Client
 from pylabnet.network.core.generic_server import GenericServer
-from pylabnet.utils.helper_methods import show_console, hide_console, load_config
+from pylabnet.utils.helper_methods import get_ip, show_console, hide_console, load_config
 
 
 
@@ -64,7 +64,7 @@ def launch(**kwargs):
     ni_daqmx_service.assign_logger(logger=ni_daqmx_logger)
     ni_daqmx_server = GenericServer(
         service=ni_daqmx_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/nidaqmx_green.py
+++ b/pylabnet/launchers/servers/nidaqmx_green.py
@@ -6,7 +6,7 @@ import os
 from pylabnet.hardware.ni_daqs import nidaqmx_card
 from pylabnet.network.client_server.nidaqmx_card import Service, Client
 from pylabnet.network.core.generic_server import GenericServer
-from pylabnet.utils.helper_methods import show_console, hide_console, load_config
+from pylabnet.utils.helper_methods import get_ip, show_console, hide_console, load_config
 
 
 
@@ -64,7 +64,7 @@ def launch(**kwargs):
     ni_daqmx_service.assign_logger(logger=ni_daqmx_logger)
     ni_daqmx_server = GenericServer(
         service=ni_daqmx_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/si_tt.py
+++ b/pylabnet/launchers/servers/si_tt.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError:
 from pylabnet.hardware.counter.swabian_instruments.time_tagger import Wrap
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.client_server.si_tt import Service, Client
-from pylabnet.utils.helper_methods import load_device_config
+from pylabnet.utils.helper_methods import get_ip, load_device_config
 
 
 def launch(**kwargs):
@@ -61,7 +61,7 @@ def launch(**kwargs):
     cnt_trace_service.assign_logger(logger=kwargs['logger'])
     cnt_trace_server = GenericServer(
         service=cnt_trace_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
     cnt_trace_server.start()

--- a/pylabnet/launchers/servers/staticline_nidaqmx.py
+++ b/pylabnet/launchers/servers/staticline_nidaqmx.py
@@ -7,6 +7,7 @@ import pylabnet.hardware.staticline.staticline as staticline
 
 from pylabnet.network.client_server.staticline import Service, Client
 import pylabnet.network.client_server.abstract_device as abstract_device
+from pylabnet.utils.helper_methods import get_ip
 
 from pylabnet.network.core.generic_server import GenericServer
 
@@ -42,7 +43,7 @@ def launch(**kwargs):
     staticline_service.assign_logger(logger=staticline_logger)
     staticline_service_server = GenericServer(
         service=staticline_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/thorlabs_pm320e.py
+++ b/pylabnet/launchers/servers/thorlabs_pm320e.py
@@ -5,7 +5,7 @@ import pyvisa
 from pylabnet.hardware.power_meter.thorlabs_pm320e import Driver
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.client_server.thorlabs_pm320e import Service, Client
-from pylabnet.utils.helper_methods import show_console, hide_console, load_device_config
+from pylabnet.utils.helper_methods import get_ip show_console, hide_console, load_device_config
 
 def launch(**kwargs):
     """ Connects to PM320E and instantiates server
@@ -57,7 +57,7 @@ def launch(**kwargs):
     pm_service.assign_logger(logger=kwargs['logger'])
     pm_server = GenericServer(
         service=pm_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
     pm_server.start()

--- a/pylabnet/launchers/servers/thorlabs_pm320e_front.py
+++ b/pylabnet/launchers/servers/thorlabs_pm320e_front.py
@@ -5,7 +5,7 @@ import pyvisa
 from pylabnet.hardware.power_meter.thorlabs_pm320e import Driver
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.client_server.thorlabs_pm320e import Service, Client
-from pylabnet.utils.helper_methods import show_console, hide_console, load_config
+from pylabnet.utils.helper_methods import get_ip, show_console, hide_console, load_config
 
 def launch(**kwargs):
     """ Connects to PM320E and instantiates server
@@ -57,7 +57,7 @@ def launch(**kwargs):
     pm_service.assign_logger(logger=kwargs['logger'])
     pm_server = GenericServer(
         service=pm_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
     pm_server.start()

--- a/pylabnet/launchers/servers/toptica_dlc_pro.py
+++ b/pylabnet/launchers/servers/toptica_dlc_pro.py
@@ -6,7 +6,7 @@ import os
 from pylabnet.hardware.lasers.toptica import DLC_Pro
 from pylabnet.network.client_server.toptica_dl_pro import Service, Client
 from pylabnet.network.core.generic_server import GenericServer
-from pylabnet.utils.helper_methods import show_console, hide_console, load_device_config
+from pylabnet.utils.helper_methods import get_ip, show_console, hide_console, load_device_config
 
 
 
@@ -31,7 +31,7 @@ def launch(**kwargs):
     dlc_service.assign_logger(logger=toptica_logger)
     dlc_server = GenericServer(
         service=dlc_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/launchers/servers/toptica_filterwheel1.py
+++ b/pylabnet/launchers/servers/toptica_filterwheel1.py
@@ -7,7 +7,7 @@ from pylabnet.hardware.filterwheel.filterwheel import FW102CFilterWheel
 from pylabnet.network.client_server.filterwheel import Service, Client
 
 from pylabnet.network.core.generic_server import GenericServer
-from pylabnet.utils.helper_methods import load_config
+from pylabnet.utils.helper_methods import load_config, get_ip
 
 
 FILTERWHEEL_NAME="Toptica Filterwheel 1"
@@ -42,10 +42,9 @@ def launch(**kwargs):
     filterwheel_service.assign_module(module=filterwheel)
     filterwheel_service.assign_logger(logger=logger)
     filterwheel_service_server = GenericServer(
-        service=filterwheel_service, 
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        service=filterwheel_service,
+        host=get_ip(),
         port=kwargs['port']
     )
 
     filterwheel_service_server.start()
-   

--- a/pylabnet/launchers/servers/toptica_filterwheel2.py
+++ b/pylabnet/launchers/servers/toptica_filterwheel2.py
@@ -7,7 +7,7 @@ from pylabnet.hardware.filterwheel.filterwheel import FW102CFilterWheel
 from pylabnet.network.client_server.filterwheel import Service, Client
 
 from pylabnet.network.core.generic_server import GenericServer
-from pylabnet.utils.helper_methods import load_config
+from pylabnet.utils.helper_methods import load_config, get_ip
 
 
 FILTERWHEEL_NAME="Toptica Filterwheel 2"
@@ -42,10 +42,9 @@ def launch(**kwargs):
     filterwheel_service.assign_module(module=filterwheel)
     filterwheel_service.assign_logger(logger=logger)
     filterwheel_service_server = GenericServer(
-        service=filterwheel_service, 
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        service=filterwheel_service,
+        host=get_ip(),
         port=kwargs['port']
     )
 
     filterwheel_service_server.start()
-   

--- a/pylabnet/launchers/servers/zi_hdawg.py
+++ b/pylabnet/launchers/servers/zi_hdawg.py
@@ -1,7 +1,7 @@
 from pylabnet.hardware.awg.zi_hdawg import Driver
 from pylabnet.network.client_server.hdawg import Service, Client
 from pylabnet.network.core.generic_server import GenericServer
-from pylabnet.utils.helper_methods import load_device_config
+from pylabnet.utils.helper_methods import load_device_config, get_ip
 
 import socket
 
@@ -20,7 +20,7 @@ def launch(**kwargs):
     hd_service.assign_logger(logger=zi_logger)
     hd_server = GenericServer(
         service=hd_service,
-        host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+        host=get_ip(),
         port=kwargs['port']
     )
 

--- a/pylabnet/scripts/counter/count_histogram.py
+++ b/pylabnet/scripts/counter/count_histogram.py
@@ -4,7 +4,7 @@ from pylabnet.gui.igui.iplot import SingleTraceFig
 from pylabnet.gui.pyqt.external_gui import Window
 from pylabnet.utils.helper_methods import (generic_save, get_gui_widgets,
     get_legend_from_graphics_view, add_to_legend, create_server, unpack_launcher,
-    load_config, pyqtgraph_save, find_client)
+    load_config, pyqtgraph_save, find_client, get_ip)
 from pylabnet.network.client_server.count_histogram import Service
 
 import numpy as np
@@ -484,7 +484,7 @@ def launch(**kwargs):
     update_service = Service()
     update_service.assign_module(module=trace)
     update_service.assign_logger(logger=logger)
-    update_server, update_port = create_server(update_service, logger, host=socket.gethostbyname_ex(socket.gethostname())[2][0])
+    update_server, update_port = create_server(update_service, logger, host=get_ip())
     logger.update_data(data={'port': update_port})
     trace.gui.set_network_info(port=update_port)
     update_server.start()

--- a/pylabnet/scripts/counter/monitor_counts.py
+++ b/pylabnet/scripts/counter/monitor_counts.py
@@ -9,7 +9,7 @@ from pylabnet.utils.logging.logger import LogClient
 from pylabnet.scripts.pause_script import PauseService
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.client_server import si_tt
-from pylabnet.utils.helper_methods import unpack_launcher, load_config, get_gui_widgets, get_legend_from_graphics_view, find_client, load_script_config
+from pylabnet.utils.helper_methods import get_ip, unpack_launcher, load_config, get_gui_widgets, get_legend_from_graphics_view, find_client, load_script_config
 
 
 # Static methods
@@ -307,7 +307,7 @@ def launch(**kwargs):
     #     try:
     #         port = np.random.randint(1, 9999)
     #         pause_server = GenericServer(
-    #             host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+    #             host=get_ip(),
     #             port=port,
     #             service=pause_service)
     #         pause_logger.update_data(data=dict(port=port))

--- a/pylabnet/scripts/lasers/laser_stabilizer.py
+++ b/pylabnet/scripts/lasers/laser_stabilizer.py
@@ -2,7 +2,7 @@ from pylabnet.scripts.pid import PID
 from pylabnet.network.core.service_base import ServiceBase
 from pylabnet.network.core.client_base import ClientBase
 from pylabnet.gui.pyqt.external_gui import Window
-from pylabnet.utils.helper_methods import (unpack_launcher, create_server,
+from pylabnet.utils.helper_methods import (get_ip, unpack_launcher, create_server,
     load_config, get_gui_widgets, get_legend_from_graphics_view, add_to_legend, find_client)
 from pylabnet.utils.logging.logger import LogClient, LogHandler
 import pylabnet.hardware.ni_daqs.nidaqmx_card as nidaqmx
@@ -392,7 +392,7 @@ def launch(**kwargs):
     update_service = Service()
     update_service.assign_module(module=laser_stabilizer)
     update_service.assign_logger(logger=logger)
-    update_server, update_port = create_server(update_service, logger, host=socket.gethostbyname_ex(socket.gethostname())[2][0])
+    update_server, update_port = create_server(update_service, logger, host=get_ip())
     logger.update_data(data={'port': update_port})
     laser_stabilizer.gui.set_network_info(port=update_port)
     update_server.start()

--- a/pylabnet/scripts/staticlines/staticline.py
+++ b/pylabnet/scripts/staticlines/staticline.py
@@ -9,7 +9,7 @@ import pylabnet.hardware.staticline.staticline as staticline
 from pylabnet.gui.pyqt.gui_windowbuilder import GUIWindowFromConfig
 
 from pylabnet.utils.logging.logger import LogHandler
-from pylabnet.utils.helper_methods import unpack_launcher, load_script_config, find_client
+from pylabnet.utils.helper_methods import get_ip, unpack_launcher, load_script_config, find_client
 
 
 class StaticLineGUIGeneric():
@@ -174,7 +174,7 @@ def launch(**kwargs):
             config=kwargs['config'],
             staticline_clients=clients,
             logger_client=logger,
-            host=socket.gethostbyname_ex(socket.gethostname())[2][0],
+            host=get_ip(),
             port=kwargs['server_port']
         )
     except KeyError:

--- a/pylabnet/utils/helper_methods.py
+++ b/pylabnet/utils/helper_methods.py
@@ -739,7 +739,7 @@ def launch_device_server(server, dev_config, log_ip, log_port, server_port, debu
         start = f'start "{server}_server, '
         start += time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime())
         start += '" '
-        host_ip = socket.gethostbyname_ex(socket.gethostname())[2][0]
+        host_ip = get_ip()
         python_path = sys.executable
         launch_path = os.path.join(
             os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
@@ -804,3 +804,16 @@ def launch_script(script, config, log_ip, log_port, debug_flag, server_debug_fla
     cmd += client_cmd
 
     subprocess.Popen(cmd, shell=True)
+
+def get_ip():
+    """ Returns a primary IP address """
+
+    ip_list = socket.gethostbyname_ex(socket.gethostname())[2]
+    if len(ip_list) == 1:
+        return ip_list[0]
+    else:
+        filtered_ip = [ip for ip in ip_list if ip.startswith('140')]
+        if len(filtered_ip) == 0:
+            return ip_list[0]
+        else:
+            return filtered_ip[0]

--- a/pylabnet/utils/logging/logger.py
+++ b/pylabnet/utils/logging/logger.py
@@ -8,7 +8,7 @@ import os
 import ctypes
 import re
 import pickle
-from pylabnet.utils.helper_methods import get_dated_subdirectory_filepath
+from pylabnet.utils.helper_methods import get_dated_subdirectory_filepath, get_ip
 
 
 class LogHandler:
@@ -190,7 +190,7 @@ class LogClient:
                 raise exc_obj
 
             client_data = dict(
-                ip=socket.gethostbyname_ex(socket.gethostname())[2][0],
+                ip=get_ip(),
                 timestamp=time.strftime("%Y-%m-%d, %H:%M:%S", time.gmtime())
             )
             if self._server_port is not None:


### PR DESCRIPTION
Implemented a helper method `get_ip()` which identifies the appropriate lab network in cases where a computer may be connected to multiple different local networks. This isn't an ideal solution, but is needed to move forward. 

Important: depreciate use of `socket.gethostbyname` if possible, since this is not reliable on machines with multiple IP addresses, use the `get_ip` helper method instead.