### PR TITLE
Mkbhaskar/issue200 - remove dangling LogClients

### DIFF
--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -211,6 +211,9 @@ class Controller:
                 host=get_ip()
             )
             my_port = self.gui_port
+            self.main_window.gui_label.setText(
+                f'GUI Port: {my_port}'
+            )
         elif self.proxy:
             self.gui_server, my_port = create_server(
                 self.gui_service,
@@ -228,6 +231,9 @@ class Controller:
                     port=self.gui_port
                 )
                 my_port = self.gui_port
+                self.main_window.gui_label.setText(
+                    f'GUI Port: {my_port}'
+                )
             except ConnectionRefusedError:
                 self.gui_logger.error(f'Failed to instantiate GUI Server at port {self.gui_port}')
                 raise
@@ -456,6 +462,7 @@ class Controller:
                     f'on host: {server_data["ip"]}, port: {server_data["port"]}'
                 )
         else:
+            self.gui_logger.info(self.log_server._server.clients)
             self.gui_logger.warn(f'No server to shutdown for client {client_to_stop}')
 
     def _device_clicked(self, index):


### PR DESCRIPTION
Added conditional statement to remove a dangling LogClient even if it doesn't have its own server to shutdown (sometimes happens in the case of bugs with a device or script). See `pylabnet.launchers.launch_control.Controller._close_dangling` for implementation. Note, I tested that this doesn't actually stop the socket from listening to this client, or kill the client thread itself. So if a thread is still running that is e.g. connected to a device, that will still be a problem. Would probably have to find the PID of that thread and kill it externally, which requires more of an overhaul (e.g. storing PIDs for each LogClient in the `client_data`)

But this solution should be satisfactory for removing dangling instances from `client_data` which are sometimes left over in buggy operation and close #200 