### PR TITLE
Cknaut/iss200: Closing of dangling servers via a staticproxy

### DIFF
--- a/pylabnet/gui/pyqt/external_gui.py
+++ b/pylabnet/gui/pyqt/external_gui.py
@@ -229,9 +229,17 @@ class Window(QtWidgets.QMainWindow):
 
     def remove_client_list_entry(self, client_to_stop):
         """ Removes item in QListWidge """
+
+        # First remove item from Active Server list
         item_to_remove = self.client_list.findItems(client_to_stop, QtCore.Qt.MatchExactly)
         remove_index = self.client_list.row(item_to_remove[0])
         self.client_list.takeItem(remove_index)
+
+        # Then remove it from all the internal lists
+        del self.controller.port_list[client_to_stop]
+        del self.controller.log_service.client_data[client_to_stop]
+        del self.controller.client_list[client_to_stop]
+        del self.controller.client_data[client_to_stop]
 
     def assign_plot(self, plot_widget, plot_label, legend_widget):
         """ Adds plot assignment request to a queue

--- a/pylabnet/gui/pyqt/external_gui.py
+++ b/pylabnet/gui/pyqt/external_gui.py
@@ -230,7 +230,7 @@ class Window(QtWidgets.QMainWindow):
     def remove_client_list_entry(self, client_to_stop):
         """ Removes item in QListWidge """
         item_to_remove = self.client_list.findItems(client_to_stop, QtCore.Qt.MatchExactly)
-        remove_index = self.client_list.row(item_to_remove)
+        remove_index = self.client_list.row(item_to_remove[0])
         self.client_list.takeItem(remove_index)
 
     def assign_plot(self, plot_widget, plot_label, legend_widget):

--- a/pylabnet/gui/pyqt/external_gui.py
+++ b/pylabnet/gui/pyqt/external_gui.py
@@ -76,7 +76,7 @@ class Window(QtWidgets.QMainWindow):
             order to debug and access Window methods directly in an interactive session
         :param max: (bool, optional) whether or not to show GUI maximized
         """
-        
+
         self.app = app  # Application instance onto which to load the GUI.
 
         if self.app is None:
@@ -226,6 +226,12 @@ class Window(QtWidgets.QMainWindow):
                 pass
 
         self.stop_button.setChecked(True)
+
+    def remove_client_list_entry(self, client_to_stop):
+        """ Removes item in QListWidge """
+        item_to_remove = self.client_list.findItems(client_to_stop, QtCore.Qt.MatchExactly)
+        remove_index = self.client_list.row(item_to_remove)
+        self.client_list.takeItem(remove_index)
 
     def assign_plot(self, plot_widget, plot_label, legend_widget):
         """ Adds plot assignment request to a queue
@@ -1256,7 +1262,7 @@ class Container:
 
 
 def fresh_popup(**params):
-    """ Creates a fresh ParameterPopup without a base GUI 
+    """ Creates a fresh ParameterPopup without a base GUI
 
     :param params: kwargs of parameters as keywords and data types
         as values
@@ -1271,7 +1277,7 @@ def fresh_popup(**params):
     )
     if operating_system == 'Windows':
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('pylabnet')
-    
+
     return app, ParameterPopup(**params)
 
 def warning_popup(message):
@@ -1288,7 +1294,7 @@ def warning_popup(message):
     )
     if operating_system == 'Windows':
         ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID('pylabnet')
-    
+
     QtWidgets.QMessageBox.critical(
         None,
         "Error",

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -505,6 +505,7 @@ class Controller:
                     del self.client_data[client_to_stop]
                 else:
                     self.gui_client.remove_client_list_entry(client_to_stop)
+                self.gui_logger.info(f'Hard kill of {client_to_stop} successfull.')
 
             except:
                 pass

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -495,15 +495,17 @@ class Controller:
         else:
             self.gui_logger.warn(f'No matching client connected to LogServer: {client_to_stop}')
             try:
-                self.main_window.client_list.takeItem(self.main_window.client_list.row(self.client_list[client_to_stop]))
+                # self.main_window.client_list.takeItem(self.main_window.client_list.row(self.client_list[client_to_stop]))
 
-                # The following two member variables don't exist for a proxy.
-                if not self.proxy:
-                    del self.port_list[client_to_stop]
-                    del self.log_service.client_data[client_to_stop]
+                # # The following two member variables don't exist for a proxy.
+                # if not self.proxy:
+                #     del self.port_list[client_to_stop]
+                #     del self.log_service.client_data[client_to_stop]
 
-                del self.client_list[client_to_stop]
-                del self.client_data[client_to_stop]
+                # del self.client_list[client_to_stop]
+                # del self.client_data[client_to_stop]
+                self.gui_client.remove_client_list_entry(client_to_stop)
+
             except:
                 pass
 

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -495,16 +495,16 @@ class Controller:
         else:
             self.gui_logger.warn(f'No matching client connected to LogServer: {client_to_stop}')
             try:
-                # self.main_window.client_list.takeItem(self.main_window.client_list.row(self.client_list[client_to_stop]))
 
-                # # The following two member variables don't exist for a proxy.
-                # if not self.proxy:
-                #     del self.port_list[client_to_stop]
-                #     del self.log_service.client_data[client_to_stop]
-
-                # del self.client_list[client_to_stop]
-                # del self.client_data[client_to_stop]
-                self.gui_client.remove_client_list_entry(client_to_stop)
+                # The following two member variables don't exist for a proxy.
+                if not self.proxy:
+                    self.main_window.client_list.takeItem(self.main_window.client_list.row(self.client_list[client_to_stop]))
+                    del self.port_list[client_to_stop]
+                    del self.log_service.client_data[client_to_stop]
+                    del self.client_list[client_to_stop]
+                    del self.client_data[client_to_stop]
+                else:
+                    self.gui_client.remove_client_list_entry(client_to_stop)
 
             except:
                 pass

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -496,9 +496,13 @@ class Controller:
             self.gui_logger.warn(f'No matching client connected to LogServer: {client_to_stop}')
             try:
                 self.main_window.client_list.takeItem(self.main_window.client_list.row(self.client_list[client_to_stop]))
-                del self.port_list[client_to_stop]
+
+                # The following two member variables don't exist for a proxy.
+                if not self.proxy:
+                    del self.port_list[client_to_stop]
+                    del self.log_service.client_data[client_to_stop]
+
                 del self.client_list[client_to_stop]
-                del self.log_service.client_data[client_to_stop]
                 del self.client_data[client_to_stop]
             except:
                 pass

--- a/pylabnet/network/client_server/external_gui.py
+++ b/pylabnet/network/client_server/external_gui.py
@@ -121,6 +121,9 @@ class Service(ServiceBase):
     def exposed_set_item_index(self, container_label, index):
         return self._module.set_item_index(container_label, index)
 
+    def exposed_remove_client_list_entry(self, client_to_stop):
+        return self._module.client_list.takeItem(client_to_stop)
+
 
 class Client(ClientBase):
 
@@ -235,6 +238,9 @@ class Client(ClientBase):
     def set_button_text(self, event_label, text):
         return self._service.exposed_set_button_text(event_label, text)
 
+    def remove_client_list_entry(self, client_to_stop):
+        return self._service.exposed_client_list.takeItem(client_to_stop)
+
     def save_gui(self, config_filename, folder_root=None, logger=None, scalars=[], labels=[]):
         """ Saves the current GUI state into a config file as a dictionary
 
@@ -286,3 +292,5 @@ class Client(ClientBase):
             for label, text in data['gui_labels'].items():
                 self.set_label(text, label)
         logger.info(f'Loaded GUI values from {get_config_filepath(config_filename, folder_root)}')
+
+

--- a/pylabnet/network/client_server/external_gui.py
+++ b/pylabnet/network/client_server/external_gui.py
@@ -122,7 +122,7 @@ class Service(ServiceBase):
         return self._module.set_item_index(container_label, index)
 
     def exposed_remove_client_list_entry(self, client_to_stop):
-        return self._module.client_list.takeItem(client_to_stop)
+        return self._module.remove_client_list_entry(client_to_stop)
 
 
 class Client(ClientBase):
@@ -239,7 +239,7 @@ class Client(ClientBase):
         return self._service.exposed_set_button_text(event_label, text)
 
     def remove_client_list_entry(self, client_to_stop):
-        return self._service.exposed_client_list.takeItem(client_to_stop)
+        return self._service.exposed_remove_client_list_entry(client_to_stop)
 
     def save_gui(self, config_filename, folder_root=None, logger=None, scalars=[], labels=[]):
         """ Saves the current GUI state into a config file as a dictionary


### PR DESCRIPTION
Removing of dangling server via proxies should now work, had to retro-fit a custom function into the external GUI class which removes the server to be closed from the master launch control. This change will then be broadcast to all proxies. 

Testing procedure:

Created device server
Shut down the PC connected to the device (before this fix, the server could now not be closed from anywhere)
Close server using new functionality
Restart PC
Start Server again

The last step takes longer than usual an is indicative of something fishy, but we should just try out this fix in real life. 