### PR TITLE
Cknaut/iss244

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/data_taker.ui
+++ b/pylabnet/gui/pyqt/gui_templates/data_taker.ui
@@ -332,44 +332,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
          <enum>QLayout::SetMinimumSize</enum>
         </property>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QLabel" name="param_9">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <family>Calibri Light</family>
-              <pointsize>12</pointsize>
-              <weight>50</weight>
-              <italic>false</italic>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">color: rgb(255, 255, 255);</string>
-            </property>
-            <property name="text">
-             <string>Data type:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="dataset">
-            <property name="styleSheet">
-             <string notr="true">color: rgb(255, 255, 255);
-font: 25 12pt &quot;Calibri Light&quot;;</string>
-            </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToContents</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <layout class="QHBoxLayout" name="horizontalLayout_3"/>
         </item>
         <item>
          <layout class="QHBoxLayout" name="preselection_layout">
@@ -658,7 +621,7 @@ color: rgb(255, 255, 255);</string>
      <x>0</x>
      <y>0</y>
      <width>2565</width>
-     <height>38</height>
+     <height>26</height>
     </rect>
    </property>
   </widget>

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -88,7 +88,7 @@ class Launcher:
         # Halt execution and wait for debugger connection if debug flag is up.
         if self.debug == 1:
             import ptvsd
-            import os
+            import os 
             # 5678 is the default attach port in the VS Code debug configurations
             self.logger.info(f"Waiting for debugger to attach to PID {os.getpid()} (launcher)")
             ptvsd.enable_attach(address=('localhost', 5678))

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -199,6 +199,7 @@ class Dataset:
         for child in self.children.values():
             child.save(filename, directory, date_dir)
 
+
     def add_params_to_gui(self, **params):
         """ Adds parameters of dataset to gui
 
@@ -743,7 +744,7 @@ class LockMonitor(Dataset):
         self.children['Cavity history'].set_data(self.v)
         self.children['Max count history'].set_data(counts)
 
-    def set_pd_demod_voltage(self, pd_voltage, demod_voltage, piezo_voltage):
+    def set_pd_demod_piezo_voltage(self, pd_voltage, demod_voltage, piezo_voltage):
         self.children['PD Transmission'].set_data(pd_voltage)
         self.children['Demodulated PC Transmission'].set_data(demod_voltage)
         self.children['Piezo Voltage'].set_data(piezo_voltage)

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -746,7 +746,7 @@ class LockMonitor(Dataset):
 
     def set_pd_demod_piezo_voltage(self, pd_voltage, demod_voltage, piezo_voltage):
         self.children['PD Transmission'].set_data(pd_voltage)
-        self.children['Demodulated PC Transmission'].set_data(demod_voltage)
+        self.children['Demodulated PD Transmission'].set_data(demod_voltage)
         self.children['Piezo Voltage'].set_data(piezo_voltage)
 
 

--- a/pylabnet/scripts/data_center/take_data.py
+++ b/pylabnet/scripts/data_center/take_data.py
@@ -135,14 +135,7 @@ class DataTaker:
         self.gui.windows = {}
             # If we're not setting up a new measurement type, just clear the data
 
-
-        ## Nedd to redo this. 
-        # self.dataset = getattr(datasets, self.gui.dataset.currentText())(
-        #     gui=self.gui,
-        #     log=self.log,
-        #     config=self.config
-        # )
-
+        # We are reading in the required base-dataset by looking at the define_dataset() as defined in the experiment script.
         try:
             classname = self.module.define_dataset()
         except AttributeError:

--- a/pylabnet/scripts/data_center/take_data.py
+++ b/pylabnet/scripts/data_center/take_data.py
@@ -134,12 +134,32 @@ class DataTaker:
                     pass
         self.gui.windows = {}
             # If we're not setting up a new measurement type, just clear the data
-        self.dataset = getattr(datasets, self.gui.dataset.currentText())(
-            gui=self.gui,
-            log=self.log,
-            config=self.config
-        )
 
+
+        ## Nedd to redo this. 
+        # self.dataset = getattr(datasets, self.gui.dataset.currentText())(
+        #     gui=self.gui,
+        #     log=self.log,
+        #     config=self.config
+        # )
+
+        try:
+            classname = self.module.define_dataset()
+        except AttributeError:
+            error_msg = "No 'define_dataset' method found in experiment script."
+            self.log.error("No 'define_dataset' method found in experiment script.")
+            return
+
+        try:
+            self.dataset = getattr(datasets, classname)(
+                gui=self.gui,
+                log=self.log,
+                config=self.config
+            )
+        except AttributeError:
+            error_msg = f"Dataset name {classname} as provided in 'define_dataset' method in experiment script is not valid."
+            self.log.error(error_msg)
+            return
 
         # Run any pre-experiment configuration
         try:

--- a/pylabnet/scripts/data_center/take_data.py
+++ b/pylabnet/scripts/data_center/take_data.py
@@ -63,11 +63,6 @@ class DataTaker:
             client_item.setToolTip(str(client_obj))
             self.gui.clients.addItem(client_item)
 
-        # Configure dataset menu
-        for name, obj in inspect.getmembers(datasets):
-            if inspect.isclass(obj) and issubclass(obj, datasets.Dataset):
-                self.gui.dataset.addItem(name)
-
         # Configure button clicks
         self.gui.configure.clicked.connect(self.configure)
         self.gui.run.clicked.connect(self.run)


### PR DESCRIPTION
Deprecated dataset-picking lockdown in datataker. Will now have to include the following function in the datataker experiment script:

```python
def define_dataset():
    return 'LockMonitor'
```

Which will define which base dataset is loaded for every experiment. 

NOTE: This change is not backwards compatible, all datataker scripts will need to be changed to include the `define_dataset` function.