### PR TITLE
Added error message when cmd is too long #239

### DIFF
--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -576,7 +576,8 @@ class Controller:
                 log_ip=self.host,
                 log_port=self.log_port,
                 server_port=server_port,
-                debug=server_debug_flag
+                debug=server_debug_flag,
+                logger=self.gui_logger
             )
 
     def _script_clicked(self, index):
@@ -641,7 +642,8 @@ class Controller:
                 debug_flag=debug_flag,
                 server_debug_flag=server_debug_flag,
                 num_clients=len(self.client_list),
-                client_cmd=bash_cmd
+                client_cmd=bash_cmd,
+                logger=self.gui_logger
             )
 
     def _load_scripts(self):

--- a/pylabnet/utils/helper_methods.py
+++ b/pylabnet/utils/helper_methods.py
@@ -775,6 +775,7 @@ def launch_device_server(server, dev_config, log_ip, log_port, server_port, debu
     if len(cmd) > 8191:
         if logger is not None:
             logger.error('Cmd too long! Server will not instantiate!')
+        return
     else:
         if logger is not None:
             logger.info("Cmd len: " + str(len(cmd)))
@@ -836,6 +837,7 @@ def launch_script(script, config, log_ip, log_port, debug_flag, server_debug_fla
     if len(cmd) > 8191:
         if logger is not None:
             logger.error('Cmd too long! Server will not instantiate!')
+        return
     else:
         if logger is not None:
             logger.info("Cmd len: " + str(len(cmd)))

--- a/pylabnet/utils/helper_methods.py
+++ b/pylabnet/utils/helper_methods.py
@@ -772,6 +772,13 @@ def launch_device_server(server, dev_config, log_ip, log_port, server_port, debu
     cmd += f'--device_id "{config_dict["device_id"]}" '
     cmd += f'--config {dev_config} --debug {debug}'
 
+    if len(cmd) > 8191:
+        if logger is not None:
+            logger.error('Cmd too long! Server will not instantiate!')
+    else:
+        logger.info("Cmd len: " + str(len(cmd)))
+
+
     if ssh:
         msg_str = f'Executing command on {hostname}:\n{cmd}'
         if logger is None:
@@ -784,7 +791,7 @@ def launch_device_server(server, dev_config, log_ip, log_port, server_port, debu
 
     return host_ip, server_port
 
-def launch_script(script, config, log_ip, log_port, debug_flag, server_debug_flag, num_clients, client_cmd):
+def launch_script(script, config, log_ip, log_port, debug_flag, server_debug_flag, num_clients, client_cmd, logger=None):
     """ Launches a script
 
     :param script: (str) name of the script. Should be the directory in which the
@@ -824,6 +831,12 @@ def launch_script(script, config, log_ip, log_port, debug_flag, server_debug_fla
     cmd += f'--config {config} --debug {debug_flag} '
     cmd += f'--server_debug {server_debug_flag}'
     cmd += client_cmd
+
+    if len(cmd) > 8191:
+        if logger is not None:
+            logger.error('Cmd too long! Server will not instantiate!')
+    else:
+        logger.info("Cmd len: " + str(len(cmd)))
 
     subprocess.Popen(cmd, shell=True)
 

--- a/pylabnet/utils/helper_methods.py
+++ b/pylabnet/utils/helper_methods.py
@@ -776,7 +776,8 @@ def launch_device_server(server, dev_config, log_ip, log_port, server_port, debu
         if logger is not None:
             logger.error('Cmd too long! Server will not instantiate!')
     else:
-        logger.info("Cmd len: " + str(len(cmd)))
+        if logger is not None:
+            logger.info("Cmd len: " + str(len(cmd)))
 
 
     if ssh:
@@ -836,7 +837,8 @@ def launch_script(script, config, log_ip, log_port, debug_flag, server_debug_fla
         if logger is not None:
             logger.error('Cmd too long! Server will not instantiate!')
     else:
-        logger.info("Cmd len: " + str(len(cmd)))
+        if logger is not None:
+            logger.info("Cmd len: " + str(len(cmd)))
 
     subprocess.Popen(cmd, shell=True)
 


### PR DESCRIPTION
For issue #239 set it up so the logger will output an error message when the command is too long (due to too many devices on the server). Not a permeant fix, but it will at least fail in a more obvious way for if we run into this in the future. 