### PR TITLE
Pulsemaster Fixes - Yan Qi

### DIFF
--- a/pylabnet/scripts/pulsemaster/pulseblock_constructor.py
+++ b/pylabnet/scripts/pulsemaster/pulseblock_constructor.py
@@ -25,7 +25,7 @@ class PulseblockConstructor():
         self.config = config
 
         if "iq_cal_path" in self.config:
-            self.iq_calibration = IQ_Calibration()
+            self.iq_calibration = IQ_Calibration(log=log)
             self.iq_calibration.load_calibration(self.config["iq_cal_path"])
 
     def default_placeholder_value(self, placeholder_name):

--- a/pylabnet/scripts/pulsemaster/pulseblock_constructor.py
+++ b/pylabnet/scripts/pulsemaster/pulseblock_constructor.py
@@ -24,6 +24,10 @@ class PulseblockConstructor():
         self.pulseblock = None
         self.config = config
 
+        if "iq_cal_path" in self.config:
+            self.iq_calibration = IQ_Calibration()
+            self.iq_calibration.load_calibration(self.config["iq_cal_path"])
+
     def default_placeholder_value(self, placeholder_name):
 
         for key in Placeholder.default_values:
@@ -112,12 +116,9 @@ class PulseblockConstructor():
             # Handle IQ mixing case
             if "iq" in arg_dict and arg_dict["iq"]:
 
-                iq_calibration = IQ_Calibration()
-                iq_calibration.load_calibration(self.config["iq_cal_path"])
-
                 (if_freq, lo_freq, phase_opt,
                 amp_i_opt, amp_q_opt,
-                dc_i_opt, dc_q_opt) = iq_calibration.get_optimal_hdawg_and_LO_values(arg_dict["mod_freq"])
+                dc_i_opt, dc_q_opt) = self.iq_calibration.get_optimal_hdawg_and_LO_values(arg_dict["mod_freq"])
 
                 self.log.info(f"if={if_freq}, lo={lo_freq}, phase={phase_opt}")
 

--- a/pylabnet/scripts/pulsemaster/pulsemaster.py
+++ b/pylabnet/scripts/pulsemaster/pulsemaster.py
@@ -1218,6 +1218,9 @@ class PulseMaster:
         # Close popup
         self.add_pb_popup.close()
 
+        # Update the plotting window (clears it)
+        self.plot_current_pulseblock()
+
     def gen_pulse_specifier(self, pulsetype_dict, pulse_data_dict):
         """ Generates instance of PulseSpecifier which contain full
         information of pulse (Pulsetype, channel_number, pulsetype, pulse_parameters,

--- a/pylabnet/scripts/pulsemaster/pulsemaster.py
+++ b/pylabnet/scripts/pulsemaster/pulsemaster.py
@@ -1354,7 +1354,7 @@ class PulseMaster:
                 if key != "tref":
                     try:
                         # Try to resolve arithmetic expression containing variables.
-                        pulsedict[key] = simple_eval(val, names=self.vars)
+                        simple_eval(val, names=self.vars)
                     except NameNotDefined:
                         typecast_error.append(key)
                         validated = False
@@ -1403,9 +1403,9 @@ class PulseMaster:
             return False, None
 
         # Check that the specified channels for IQ are not in the same core
-        if len(pulse_ch_list) > 1:
-            # Subtract 1 to make 0-indexed
-            ch_num_list = [(self.ch_assignment_dict[ch][1] - 1) for ch in pulse_ch_list]
+        # if len(pulse_ch_list) > 1:
+        #     # Subtract 1 to make 0-indexed
+        #     ch_num_list = [(self.ch_assignment_dict[ch][1] - 1) for ch in pulse_ch_list]
 
             # Divide by 2 to see if same core (e.g. channels 0, 1 // 2 = 0)
             # ch_num_list = [ch//2 for ch in ch_num_list]

--- a/pylabnet/scripts/pulsemaster/pulsemaster.py
+++ b/pylabnet/scripts/pulsemaster/pulsemaster.py
@@ -159,6 +159,12 @@ class PulseMaster:
         # Apply all custom styles
         self.apply_custom_styles()
 
+        # Set the number of plotting points for the pulse preview window
+        if "plot_points" in self.config_dict:
+            self.plot_points = self.config_dict["plot_points"]
+        else:
+            self.plot_points = 800 # Default value
+
         self.awg_running = False
 
     def apply_custom_styles(self):
@@ -549,7 +555,7 @@ class PulseMaster:
                     t1, t2 = new_t1, new_t2
 
                     # Draw the current pulse at high grid density
-                    t_ar = np.linspace(t1, t2, 800)
+                    t_ar = np.linspace(t1, t2, self.plot_points)
                     x_ar.extend(t_ar)
                     y_ar.extend(p_item.get_value(t_ar))
 

--- a/pylabnet/scripts/pulsemaster/pulsemaster.py
+++ b/pylabnet/scripts/pulsemaster/pulsemaster.py
@@ -549,7 +549,7 @@ class PulseMaster:
                     t1, t2 = new_t1, new_t2
 
                     # Draw the current pulse at high grid density
-                    t_ar = np.linspace(t1, t2, 2000)
+                    t_ar = np.linspace(t1, t2, 800)
                     x_ar.extend(t_ar)
                     y_ar.extend(p_item.get_value(t_ar))
 

--- a/pylabnet/scripts/pulsemaster/pulsemaster.py
+++ b/pylabnet/scripts/pulsemaster/pulsemaster.py
@@ -11,8 +11,7 @@ from PyQt5.QtWidgets import QShortcut,  QToolBox, QFileDialog,  QMessageBox, QPu
                             QFormLayout, QComboBox, QWidget, QTableWidgetItem, QVBoxLayout, \
                             QTableWidgetItem, QCompleter, QLabel, QLineEdit, QCheckBox, QGridLayout
 from PyQt5.QtGui import QKeySequence
-from PyQt5.QtCore import QRect, Qt, QAbstractTableModel
-from PyQt5.QtCore import QVariant
+from PyQt5.QtCore import QRect, Qt, QAbstractTableModel, QTimer, QVariant
 
 from simpleeval import simple_eval, NameNotDefined
 
@@ -144,6 +143,9 @@ class PulseMaster:
         self.seq_var_table.setModel(self.seq_variable_table_model)
 
         self.add_pb_popup = None
+
+        # Initialize timers for controlling when text boxes get updated
+        self.timers = []
 
         # Initialize preserve_bits checkbox state in dictionary
         self.update_preserve_bits()
@@ -971,7 +973,12 @@ class PulseMaster:
             elif type(field_input) is QLineEdit:
                 field_input.setText(str(value))
 
-                field_input.textEdited.connect(pulse_mod_function)
+                # Create a timer to prevent the pulse update function from being called immediately
+                self.timers.append(QTimer())
+                self.timers[-1].setSingleShot(True)
+                self.timers[-1].setInterval(300)
+                self.timers[-1].timeout.connect(pulse_mod_function)
+                field_input.textEdited.connect(self.timers[-1].start)
 
             elif type(field_input) is QCheckBox:
                 field_input.setChecked(bool(value))

--- a/pylabnet/scripts/pulsemaster/pulsemaster.py
+++ b/pylabnet/scripts/pulsemaster/pulsemaster.py
@@ -868,11 +868,11 @@ class PulseMaster:
                 var_parent_field.setEnabled(True)
                 var_parent_field.setText("")
 
-            # If the t0 term is variable, we must set to "after last pulse",
+            # If the t0 term is variable, we must set to "At End of Sequence",
             # otherwise we have no idea when the pulse happens.
             if field_var == "offset_var":
                 tref_field = widgets_dict["tref"]
-                tref_field.setCurrentIndex(tref_field.findText("After Last Pulse"))
+                tref_field.setCurrentIndex(tref_field.findText("At End of Sequence"))
                 self.update_pulse_form_field(pulse_specifier, tref_field, "tref", widgets_dict, pulse_index)
 
             # Store the updated value in parent

--- a/pylabnet/utils/iq_upconversion/iq_calibration.py
+++ b/pylabnet/utils/iq_upconversion/iq_calibration.py
@@ -27,8 +27,9 @@ from pylabnet.network.client_server.agilent_83732b import Client
 
 class IQ_Calibration():
 
-	def __init__(self):
+	def __init__(self, log=None):
 		self.initialized = False
+		self.log = log
 
 	def load_calibration(self, filename):
 		self.initialized = True
@@ -283,7 +284,7 @@ class IQ_Calibration():
 		if (not self.initialized):
 			raise ValueError("No calibration loaded!")
 
-		#Computing the optimal I and Q amplitudes
+		# Computing the optimal I and Q amplitudes
 		q_opt, phase_opt = self.get_ampl_phase(if_freq, lo_freq)
 		amp_i_opt = 2 * q_opt / (1 + q_opt) * self.IF_volt
 		amp_q_opt = 2 * self.IF_volt / (1 + q_opt)
@@ -293,7 +294,7 @@ class IQ_Calibration():
 		return phase_opt, amp_i_opt, amp_q_opt, dc_i_opt, dc_q_opt
 
 	def set_optimal_hdawg_and_LO_values(self, hd, mw_source, freq, HDAWG_ports=[3,4], oscillator=2):
-		'''Finds optimnal IF and LO frequencies for given output frequency.
+		'''Finds optimal IF and LO frequencies for given output frequency.
 		Sets the optimal sine output values on the hdawg for the found IF
 		and LO frequencies. Will also set the HDAWG's sine frequency and LO
 		frequency to the correct value.'''
@@ -351,7 +352,7 @@ class IQ_Calibration():
 
 		for iff in if_f:
 			lof = freq-iff
-			if lof > LO[0] and lof < LO[-1]:
+			if LO[0] < lof < LO[-1]:
 				hm1, h0, h1, h2, h3 = self.get_harmonic_powers(iff, lof)
 				fidelity.append(self.get_fidelity(hm1, h0, h1, h2, h3, iff))
 			else:

--- a/pylabnet/utils/pulseblock/pulse_block.py
+++ b/pylabnet/utils/pulseblock/pulse_block.py
@@ -2,8 +2,8 @@ import numpy as np
 import copy
 
 class Channel:
-    """ Class to represent a signal channel. 
-    """ 
+    """ Class to represent a signal channel.
+    """
     def __init__(self, name, is_analog):
         self.name = name
         self.is_analog = is_analog
@@ -102,6 +102,8 @@ class PulseBlock:
         self.p_dict = dict()
         self.dflt_dict = dict()
         self.use_auto_dflt = use_auto_dflt
+        self.latest_t0 = 0
+        self.latest_dur = 0
 
         if dflt_dict is not None:
             self.dflt_dict = copy.deepcopy(dflt_dict)
@@ -207,7 +209,7 @@ class PulseBlock:
                         )
                     )
 
-        
+
         # Check if the channel already exists with the samne name but a
         # different type
         for key in self.p_dict.keys():
@@ -237,7 +239,9 @@ class PulseBlock:
         if use_auto_dflt:
             self.dflt_dict[ch] = p_obj.auto_default
 
-
+        # Update the latest values that have been added to the PB
+        self.latest_t0 = p_obj.t0
+        self.latest_dur = p_obj.dur
 
     def insert(self, p_obj, cflct_er=True):
         """ Insert a new Pulse object into PulseBlock
@@ -433,6 +437,10 @@ class PulseBlock:
                 self.dflt_dict[ch] = copy.deepcopy(
                     pb_obj.dflt_dict[ch]
                 )
+
+        # Update the latest values that have been added to the PB
+        self.latest_t0 = t0
+        self.latest_dur = pb_obj.dur
 
     def join_pb(self, pb_obj, t0=0, cflct_er=True, name=''):
         """ Same as insert_pb(), but instead of modifying self,


### PR DESCRIPTION
- Fixes #234 
Added a timer for each text box widget (300 ms) that acts as a delay before the box's modified function is called. The timers are stored in a list to avoid them from being garbage collected

- Fixes #243 
Implemented new fields `latest_t0` and `latest_dur` in `PulseBlock` to remember the properties of the last pulse added. This was used to cleanly compute the relative pulse timings in `pulseblock_constructor.py` more cleanly. The Q pulse is implemented to always follow the I pulse more cleanly. Renamed some pulse timing methods:

1. "After Last Pulse" --> "At End of Sequence"
This refers to placing a new pulse all the way at the end of the entire pulseblock
2. "With Last Pulse" --> "With Previous Pulse", New command: "After Previous Pulse"
These 2 refer to place a new pulse at the same time/right after the previous pulse (as ordered in the pulseblock viewer GUI)
3. "After Last Pulse on Channel" -- unchanged
This refers to placing a new pulse right after the last pulse that is currently present in that specified channel

- Fixes #227 
Removed a line in `clean_and_validate_pulsedict` which assigned the evaluated value of a variable to the `pulsedict` instead of keeping it as the variable string.

- Fixes #235 
Reduced the number of points from 2000 to 800. Most of the lag (0.5s) when using IQ pulses is due to the `for` loop in `get_optimal_hdawg_and_LO_values` so we can optimize that in the future if necessary. A possible solution is to fix the LO frequency, which allows us to immediately use the `get_optimal_hdawg_values` method instead.

- Fixes #233 
Perform `plot_current_pulseblock` when a new pulseblock is created.