### PR TITLE
Patchfix for Logger Stopping Issue

### DIFF
--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -981,7 +981,7 @@ class ProxyUpdater(QtCore.QObject):
     @QtCore.pyqtSlot()
     def run(self):
         while True:
-            time.sleep(0.1)
+            time.sleep(0.001)
             # Check clients and update
             self.controller._pull_connections()
 


### PR DESCRIPTION
This relates to #230.

Turns out the freezing logger issue occurs if two new logger statements are posted within the loop time of the main loop of the `ProxyUpdater` thread. This value was currently >0.1s, thanks to a 0.1s sleeptime. This meant that whenever two new logger statements did arrive within a 0.1s window, subsequent logging would stop. Heavily decreasing the waittime makes the occurrence of such "double-logging" events less likely. I tested this by manually clogging the logger, and it seems to work.

This is only a somewhat ugly patchfix and eventually we should look into the root cause for the freeze-up. But let's merge this into the master and see if it fixes our issues.  