### PR TITLE
Various fixes 

### DIFF
--- a/pylabnet/hardware/staticline/staticline_devices.py
+++ b/pylabnet/hardware/staticline/staticline_devices.py
@@ -3,7 +3,7 @@ from pylabnet.utils.helper_methods import load_config
 from pylabnet.hardware.awg.awg_utils import convert_awg_pin_to_dio_board
 
 # Maximal output for Hittite MW source
-MW_MAXVAL = 20
+MW_MAXVAL = 25
 class StaticLineHardwareHandler(ABC):
     '''Handler connecting hardware class to StaticLine instance
 
@@ -215,6 +215,9 @@ class HMCT2220(StaticLineHardwareHandler):
             value = self.maxval
 
         self.hardware_client.set_power(float(value))
+    def set_value(self, value):
+        #This will be used for setting the frequencies with an analog staticline
+        self.hardware_client.set_freq(float(value)*1E9)
 
 
 class TPLinkHS103(StaticLineHardwareHandler):

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -981,7 +981,7 @@ class ProxyUpdater(QtCore.QObject):
     @QtCore.pyqtSlot()
     def run(self):
         while True:
-            time.sleep(0.1)
+            time.sleep(0.001)
             # Check clients and update
             self.controller._pull_connections()
 

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -87,13 +87,13 @@ class Launcher:
 
         # Halt execution and wait for debugger connection if debug flag is up.
         if self.debug == 1:
-            import ptvsd
-            import os 
+            import debugpy
+            import os
             # 5678 is the default attach port in the VS Code debug configurations
             self.logger.info(f"Waiting for debugger to attach to PID {os.getpid()} (launcher)")
-            ptvsd.enable_attach(address=('localhost', 5678))
-            ptvsd.wait_for_attach()
-            breakpoint()
+            debugpy.listen(('localhost', 5678))
+            debugpy.wait_for_client()
+            debugpy.breakpoint()
 
         # Register new exception hook.
         def log_exceptions(exc_type, exc_value, exc_traceback):

--- a/pylabnet/launchers/pylabnet_server.py
+++ b/pylabnet/launchers/pylabnet_server.py
@@ -22,7 +22,6 @@ import numpy as np
 import os
 import sys
 import traceback
-import ptvsd
 import time
 
 from pylabnet.utils.helper_methods import parse_args, hide_console
@@ -78,11 +77,12 @@ def main():
 
     # Halt execution and wait for debugger connection if debug flag is up.
     if debug:
+        import debugpy
         # 5678 is the default attach port in the VS Code debug configurations
         server_logger.info(f"Waiting for debugger to attach to PID {os.getpid()} (pylabnet_server)")
-        ptvsd.enable_attach(address=('localhost', 5678))
-        ptvsd.wait_for_attach()
-        breakpoint()
+        debugpy.listen(('localhost', 5678))
+        debugpy.wait_for_client()
+        debugpy.breakpoint()
 
     # Register new exception hook.
     def log_exceptions(exc_type, exc_value, exc_traceback):

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -127,7 +127,7 @@ class Dataset():
     def clear_data(self):
         self.data = None
         self.curve.setData([])
-        
+
     # Note: This recursive code could potentially run into infinite iteration problem.
     def clear_all_data(self):
 
@@ -137,7 +137,7 @@ class Dataset():
 
         for child in self.children.values():
             child.clear_all_data()
-            
+
 
     def update(self, **kwargs):
         """ Updates current data to plot"""
@@ -939,7 +939,7 @@ class TriangleScan1D(Dataset):
                     prev_dataset.data = np.fliplr(prev_dataset.data)
                 except ValueError:
                     prev_dataset.data = np.flip(prev_dataset.data)
-    
+
 class SawtoothScan1D(Dataset):
     """ 1D Sawtooth sweep of a parameter """
 
@@ -1155,7 +1155,7 @@ class HeatMap(Dataset):
             img=np.transpose(np.zeros((10,10))),
             autoRange=False
         )
-        
+
         self.data = None
 
 
@@ -1208,7 +1208,7 @@ class LockedCavityScan1D(TriangleScan1D):
         self.children['Cavity history'].set_data(self.v)
         self.children['Max count history'].set_data(counts)
 
-    
+
     def clear_data(self):
 
         # Clear forward/backward scan line
@@ -1217,7 +1217,7 @@ class LockedCavityScan1D(TriangleScan1D):
 
         # Clear retasined data used in heatmaps
         self.all_data = None
-      
+
 
 class LockedCavityPreselectedHistogram(PreselectedHistogram):
 
@@ -1271,6 +1271,7 @@ class LockedCavityPreselectedHistogram(PreselectedHistogram):
         # self.widgets['voltage'].setValue(self.v)
         self.children['Cavity history'].set_data(self.v)
         self.children['Max count history'].set_data(counts)
+
 
 class ErrorBarGraph(Dataset):
 

--- a/pylabnet/scripts/data_center/take_data.py
+++ b/pylabnet/scripts/data_center/take_data.py
@@ -49,6 +49,11 @@ class DataTaker:
         # Configure list of missing clients
         self.missing_clients = {}
 
+        # Setup Autosave
+        if self.config['auto_save']:
+            self.gui.autosave.setChecked(True)
+
+
         # Retrieve Clients
         for client_entry in self.config['servers']:
             client_type = client_entry['type']

--- a/pylabnet/scripts/fiber_coupling/mcs2_control.py
+++ b/pylabnet/scripts/fiber_coupling/mcs2_control.py
@@ -257,6 +257,8 @@ class Controller:
                 self._update_voltage(channel, 0)
 
             self._set_voltage_display(channel)
+        else:
+            self.log.info("LOCKED")
 
     def _step_right(self, channel: int):
         """ Steps a particular channel if unlocked

--- a/pylabnet/scripts/pulsemaster/pulsemaster.py
+++ b/pylabnet/scripts/pulsemaster/pulsemaster.py
@@ -96,6 +96,9 @@ class PulseMaster:
         # Initialize empty pulseblock dictionary.
         self.pulseblocks = {}
 
+        # Store filepath to sequence vars
+        self.seq_var_filepath = None
+
         # Initialize empty dictionary containing the contruction
         # Instructions for the currently displayed pulseblock.
         self.pulseblock_constructors = []
@@ -286,7 +289,7 @@ class PulseMaster:
         """ Load PB constructor from file"""
 
         # Get filename from pop-up.
-        pb_dict = self.load_json_dict()
+        pb_dict, _ = self.load_json_dict()
 
         # Create pulseblock contructor.
         imported_contructor = self.get_pb_constructor_from_dict(pb_dict)
@@ -355,6 +358,9 @@ class PulseMaster:
         # Stop AWG if it's running.
         if self.awg_running:
             self.stop_hdawg()
+
+        # Update sequence var dict
+        self.get_seq_var_dict_from_previous()
 
         # Get sequence template from textbox.
         seq_template = self.widgets['seqt_textedit'].toPlainText()
@@ -469,11 +475,8 @@ class PulseMaster:
         """
         return dict(self.seq_variable_table_model.datadict)
 
-    def get_seq_var_dict_from_file(self):
-        """ Load assignment dictionary from file."""
-
-        # Get filepath from file-sepector popup.
-        seq_var_dict = self.load_json_dict()
+    def set_seq_var_dict(self, seq_var_dict):
+        """ Initialize Sequencer Variable table. """
 
         # Retrieve sub-dictionary
         seq_var_dict = seq_var_dict['sequence_vars']
@@ -491,6 +494,20 @@ class PulseMaster:
 
         self.seq_var_table.setModel(self.seq_variable_table_model)
 
+    def get_seq_var_dict_from_file(self):
+        """ Load assignment dictionary from file."""
+
+        # Get filepath from file-sepector popup.
+        seq_var_dict, filename = self.load_json_dict()
+        self.seq_var_filepath = filename
+        self.set_seq_var_dict(seq_var_dict)
+
+    def get_seq_var_dict_from_previous(self):
+        """ Read at stored sequence variable dict filepaths and loads it"""
+        if  self.seq_var_filepath is not None:
+            f = open(self.seq_var_filepath)
+            seq_var_dict = json.load(f)
+            self.set_seq_var_dict(seq_var_dict)
 
     def get_filename(self, filetype="JSON files (*.json)"):
         """Open file selector widget and get files."""
@@ -507,7 +524,7 @@ class PulseMaster:
         # a dictionary
         dictionary = json.load(f)
 
-        return dictionary
+        return dictionary, filename[0]
 
     def prep_plotdata(self, pb_obj):
 

--- a/pylabnet/scripts/sweeper/scan_1d.py
+++ b/pylabnet/scripts/sweeper/scan_1d.py
@@ -309,8 +309,9 @@ class Controller(MultiChSweep1D):
                 date_dir=date_dir
             )
 
-        else:
-            if self.data_bwd:
+        '''else:
+
+            if len(self.data_bwd) > 0:
                 # Save heatmap
                 generic_save(
                     data=fill_2dlist(self.data_bwd),
@@ -336,7 +337,7 @@ class Controller(MultiChSweep1D):
                     filename=f'{filename}_bwd_avg',
                     directory=directory,
                     date_dir=date_dir
-                )
+                )'''
 
     def fit_config(self, status:bool):
         """ Configures fitting add-on

--- a/pylabnet/utils/iq_upconversion/iq_calibration.py
+++ b/pylabnet/utils/iq_upconversion/iq_calibration.py
@@ -362,11 +362,16 @@ class IQ_Calibration():
 		LO = np.array(self.phase.index)
 		IF = np.array(self.phase.columns.get_level_values(1))
 
+		default_if = 2e6
+		default_lo = 12e9
+
 		if freq < LO[0] + IF[0]:
-			raise ValueError("Chosen frequency too low!")
+			return default_if, default_lo
+			#raise ValueError("Chosen frequency too low!")
 
 		if freq > LO[-1] + IF[-1]:
-			raise ValueError("Chosen frequency too high!")
+			return default_if, default_lo
+			#raise ValueError("Chosen frequency too high!")
 
 		if_f = np.linspace(LO[0], LO[-1], 100)
 
@@ -398,11 +403,21 @@ class IQ_Calibration():
 		LO = np.array(self.phase.index)
 		IF = np.array(self.phase.columns.get_level_values(1))
 
+		default_if = 200e6
+		default_lo = 12e9
+		default_phase_opt = np.array([0])
+		default_amp_i_opt = np.array([1])
+		default_amp_q_opt = np.array([1])
+		default_dc_i_opt = np.array([0])
+		default_dc_q_opt = np.array([0])
+
 		if freq < LO[0] + IF[0]:
-			raise ValueError("Chosen frequency too low!")
+			return default_if, default_lo, default_phase_opt, default_amp_i_opt, default_amp_q_opt, default_dc_i_opt, default_dc_q_opt
+			#raise ValueError("Chosen frequency too low!")
 
 		if freq > LO[-1] + IF[-1]:
-			raise ValueError("Chosen frequency too high!")
+			return default_if, default_lo, default_phase_opt, default_amp_i_opt, default_amp_q_opt, default_dc_i_opt, default_dc_q_opt
+			#raise ValueError("Chosen frequency too high!")
 
 		if_f = np.linspace(IF[0], IF[-1], 100)
 
@@ -427,7 +442,7 @@ class IQ_Calibration():
 
 def main():
 	mw_client = Client(
-		host='192.168.50.104', 
+		host='192.168.50.104',
 		port=25696
 	)
 	sa = agilent_e4405B.Client(

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "Topic :: Scientific/Engineering :: Physics"
     ],
     install_requires=[
+        'debugpy>=1.3.0',
         'decorator>=4.4.0',
         'ipywidgets>=7.5.1',
         'matplotlib>=3.1.3',
@@ -64,7 +65,6 @@ setup(
         'numpy>=1.16.5',
         'paramiko>=2.7.2',
         'plotly>=4.7.1',
-        'ptvsd>=4.3.2',
         'PyQt5>=5.13.0',
         'pyqtgraph>=0.10.0',
         'pyserial>=3.4',


### PR DESCRIPTION
Various fixes, namely:

Closes #270.  Datataker config file now need to contain the attribute `auto_save`,  which if set to true will start the datataker with autosave enabled.

Closes #273. Can now use shift-select and control-select to select multiple servers in the server list of launchers. Convenient for closing multiple servers.

Fixed #270: Pulsermaster now reloads sequence var dict before every AWG upload. 

Moved from `ptvsd` to `debugpy` as remote debugging solution (`ptvsd` is deprecated). 

