### PR TITLE
Fix histogram filename not used

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/histogram.ui
+++ b/pylabnet/gui/pyqt/gui_templates/histogram.ui
@@ -545,11 +545,17 @@ color: rgb(255, 255, 255);</string>
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="save_name">
-        <property name="maximumSize">
+       <widget class="QLineEdit" name="save_name">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
          <size>
-          <width>16777215</width>
-          <height>16777215</height>
+          <width>180</width>
+          <height>0</height>
          </size>
         </property>
         <property name="font">
@@ -558,17 +564,8 @@ color: rgb(255, 255, 255);</string>
           <pointsize>12</pointsize>
          </font>
         </property>
-        <property name="styleSheet">
-         <string notr="true">color: rgb(255, 255, 255);</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
         <property name="text">
          <string>histogram</string>
-        </property>
-        <property name="textInteractionFlags">
-         <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextEditable|Qt::TextEditorInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
         </property>
        </widget>
       </item>

--- a/pylabnet/scripts/counter/count_histogram.py
+++ b/pylabnet/scripts/counter/count_histogram.py
@@ -249,10 +249,7 @@ class TimeTraceGui(TimeTrace):
             n_bins=self.gui.n_bins.value()
         ))
         self.gui.clear.clicked.connect(self.clear_all)
-        self.gui.save.clicked.connect(lambda: self.save(
-            filename=self.gui.save_name.text(),
-            directory=self.config['save_path']
-        ))
+        self.gui.save.clicked.connect(self.save)
         self.gui.run.clicked.connect(self.run)
 
         #### CHANGED CHANGED CHANGED
@@ -355,10 +352,7 @@ class TimeTraceGui(TimeTrace):
             self.gui.run.setStyleSheet('background-color: green')
             self.log.info('Stopped histogram')
             if self.gui.autosave.isChecked():
-                self.save(
-                    filename=self.gui.save_name.text(),
-                    directory=self.config['save_path']
-                )
+                self.save()
             self.pause()
             for gate in self.gates.values():
                 gate.pause()
@@ -379,10 +373,7 @@ class TimeTraceGui(TimeTrace):
             if self.gui.autosave.isChecked():
                 current_time = time.time()
                 if current_time - last_save > self.gui.save_time.value():
-                    self.save(
-                        filename=self.gui.save_name.text(),
-                        directory=self.config['save_path']
-                    )
+                    self.save()
                     last_save = current_time
             if self.gui.auto_clear.isChecked():
                 current_time = time.time()
@@ -511,6 +502,12 @@ class TimeTraceGui(TimeTrace):
 
     def save(self, filename=None, directory=None):
         """ Saves the current data """
+
+        if filename is None:
+            filename = self.gui.save_name.text()
+
+        if directory is None:
+            directory = self.config['save_path']
 
         generic_save(
             data=np.array([

--- a/pylabnet/scripts/counter/count_histogram.py
+++ b/pylabnet/scripts/counter/count_histogram.py
@@ -249,7 +249,9 @@ class TimeTraceGui(TimeTrace):
             n_bins=self.gui.n_bins.value()
         ))
         self.gui.clear.clicked.connect(self.clear_all)
-        self.gui.save.clicked.connect(self.save)
+        # Need Lambda to force it to use default args
+        # https://stackoverflow.com/questions/60001583/pyqt5-slot-function-does-not-take-default-argument
+        self.gui.save.clicked.connect(lambda: self.save())
         self.gui.run.clicked.connect(self.run)
 
         #### CHANGED CHANGED CHANGED


### PR DESCRIPTION
Fix issue #305 

- Changed QLabel to QLineEdit for the filename field
- Changed the save button to read the filename on save instead of on button function assignment  