### PR TITLE
Readme, prereqs, and installation requirements update

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pip install -r requirements.txt
 
 > **_NOTE:_** If it fails, try upgrading pip with `python -m pip install --upgrade pip`.
 
-Finally, navigate to the root directory in the commandline and run the command to install `pylabnet`:
+Finally, run the command to install `pylabnet`:
 ```bash
 python setup.py develop
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,6 @@ pscript==0.7.5
 ptvsd==5.0.0a12
 pycparser==2.20
 Pygments==2.8.0
--e git+https://github.com/lukingroup/pylabnet.git@462033d0da614a217f04b733f99e69b92d7d8ada#egg=pylabnet
 pylint==2.6.2
 pynacl==1.4.0
 pyparsing==2.4.7

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     license='MIT',
     packages=find_packages(),
     include_package_data=True,
-    python_requires='>=3.7',  # This may not be strictly necessary
+    python_requires='>=3.7, <3.9',  # 3.9 and above requires newer version of zhinst
     entry_points={
         'console_scripts': [
             'pylabnet=pylabnet.launchers.launch_control:main',


### PR DESCRIPTION
Fixed #316 
- Added new prerequisite to only support Python versions 3.7 and 3.8 due to package dependencies
- Updated readme instructions to include a step for installing from `requirements.txt` first so that all package versions are consistent
- Removed `pylabnet` itself from `requirements.txt`
- Added an instruction to create `static_proxy.json` when running master Pylabnet
- Misc documentation about proxies and servers