### PR TITLE
Wavemeter lock bugfix: fixes #349

### DIFF
--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -33,7 +33,7 @@ class Dataset():
             self.config = kwargs['config']
         else:
             self.config = {}
-        
+
         if(log is None):
             self.metadata = None
         else:
@@ -97,7 +97,7 @@ class Dataset():
 
         if data_type is None:
             data_type = self.__class__
-        
+
         self.children[name] = data_type(
             gui=self.gui,
             data=self.data,
@@ -611,7 +611,7 @@ class time_trace_monitor(RollingLine):
             # If we need to process the child data, do it
             if name in self.mapping:
                 self.mapping[name](self, prev_dataset=child)
-        
+
 
 
 class ManualOpenLoopScan(Dataset):
@@ -1143,7 +1143,7 @@ class HeatMap(Dataset):
         self.graph.show()
         self.graph.view.setAspectLocked(False)
         self.graph.view.invertY(False)
-        self.graph.setPredefinedGradient('inferno')
+        self.graph.setPredefinedGradient('viridis')
         if set(['min', 'max', 'pts']).issubset(kwargs.keys()):
             self.min, self.max, self.pts = kwargs['min'], kwargs['max'], kwargs['pts']
             self.graph.view.setLimits(xMin=kwargs['min'], xMax=kwargs['max'])

--- a/pylabnet/scripts/lasers/wlm_monitor.py
+++ b/pylabnet/scripts/lasers/wlm_monitor.py
@@ -539,16 +539,13 @@ class Channel:
 
         self.data = np.ones(display_pts) * wavelength
 
-        # if self.sp_data already exists, keep its last value so that the 
+        # if self.sp_data already exists, keep its last value so that the
         # clear data functionality doesn't override the setpoint
-        try:
-            if len(self.sp_data) > 0:
-                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
-            else:
-                self.sp_data = np.ones(display_pts) * self.data[-1]
-        except:
+        if len(self.sp_data) > 0:
+            self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+        else:
             self.sp_data = np.ones(display_pts) * self.data[-1]
-        
+
         self.setpoint = self.sp_data[-1]
 
         # Initialize voltage and error

--- a/pylabnet/scripts/lasers/wlm_monitor.py
+++ b/pylabnet/scripts/lasers/wlm_monitor.py
@@ -227,7 +227,7 @@ class WlmMonitor:
     def zero_voltage(self, channel):
         """ Zeros the output voltage for this channel
 
-        :param channel: Channel object to zero voltage of
+        :param channel: Channel object to zero voltage
         """
 
         try:

--- a/pylabnet/scripts/lasers/wlm_monitor.py
+++ b/pylabnet/scripts/lasers/wlm_monitor.py
@@ -539,11 +539,17 @@ class Channel:
 
         self.data = np.ones(display_pts) * wavelength
 
-        self.sp_data = np.ones(display_pts) * self.data[-1]
-        self.setpoint = self.data[-1]
-        # self.setpoint_override = True
-
-        # self.lock_override = True
+        # if self.sp_data already exists, keep its last value so that the 
+        # clear data functionality doesn't override the setpoint
+        try:
+            if len(self.sp_data) > 0:
+                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+            else:
+                self.sp_data = np.ones(display_pts) * self.data[-1]
+        except:
+            self.sp_data = np.ones(display_pts) * self.data[-1]
+        
+        self.setpoint = self.sp_data[-1]
 
         # Initialize voltage and error
         self.voltage = np.ones(display_pts) * self.current_voltage

--- a/pylabnet/scripts/lasers/wlm_monitor_b16.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_b16.py
@@ -540,13 +540,13 @@ class Channel:
 
         # if self.sp_data already exists, keep its last value so that the
         # clear data functionality doesn't override the setpoint
-        try:
-            if len(self.sp_data) > 0:
-                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
-            else:
-                self.sp_data = np.ones(display_pts) * self.data[-1]
-        except:
+        # try:
+        if len(self.sp_data) > 0:
+            self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+        else:
             self.sp_data = np.ones(display_pts) * self.data[-1]
+        # except:
+        #     self.sp_data = np.ones(display_pts) * self.data[-1]
 
         self.setpoint = self.sp_data[-1]
 

--- a/pylabnet/scripts/lasers/wlm_monitor_b16.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_b16.py
@@ -538,11 +538,17 @@ class Channel:
 
         self.data = np.ones(display_pts) * wavelength
 
-        self.sp_data = np.ones(display_pts) * self.data[-1]
-        self.setpoint = self.data[-1]
-        # self.setpoint_override = True
+        # if self.sp_data already exists, keep its last value so that the
+        # clear data functionality doesn't override the setpoint
+        try:
+            if len(self.sp_data) > 0:
+                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+            else:
+                self.sp_data = np.ones(display_pts) * self.data[-1]
+        except:
+            self.sp_data = np.ones(display_pts) * self.data[-1]
 
-        # self.lock_override = True
+        self.setpoint = self.sp_data[-1]
 
         # Initialize voltage and error
         self.voltage = np.ones(display_pts) * self.current_voltage

--- a/pylabnet/scripts/lasers/wlm_monitor_b16.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_b16.py
@@ -540,13 +540,10 @@ class Channel:
 
         # if self.sp_data already exists, keep its last value so that the
         # clear data functionality doesn't override the setpoint
-        # try:
         if len(self.sp_data) > 0:
             self.sp_data = np.ones(display_pts) * self.sp_data[-1]
         else:
             self.sp_data = np.ones(display_pts) * self.data[-1]
-        # except:
-        #     self.sp_data = np.ones(display_pts) * self.data[-1]
 
         self.setpoint = self.sp_data[-1]
 

--- a/pylabnet/scripts/lasers/wlm_monitor_ford.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_ford.py
@@ -539,11 +539,17 @@ class Channel:
 
         self.data = np.ones(display_pts) * wavelength
 
-        self.sp_data = np.ones(display_pts) * self.data[-1]
-        self.setpoint = self.data[-1]
-        # self.setpoint_override = True
+        # if self.sp_data already exists, keep its last value so that the
+        # clear data functionality doesn't override the setpoint
+        try:
+            if len(self.sp_data) > 0:
+                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+            else:
+                self.sp_data = np.ones(display_pts) * self.data[-1]
+        except:
+            self.sp_data = np.ones(display_pts) * self.data[-1]
 
-        # self.lock_override = True
+        self.setpoint = self.sp_data[-1]
 
         # Initialize voltage and error
         self.voltage = np.ones(display_pts) * self.current_voltage

--- a/pylabnet/scripts/lasers/wlm_monitor_ford.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_ford.py
@@ -541,12 +541,9 @@ class Channel:
 
         # if self.sp_data already exists, keep its last value so that the
         # clear data functionality doesn't override the setpoint
-        try:
-            if len(self.sp_data) > 0:
-                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
-            else:
-                self.sp_data = np.ones(display_pts) * self.data[-1]
-        except:
+        if len(self.sp_data) > 0:
+            self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+        else:
             self.sp_data = np.ones(display_pts) * self.data[-1]
 
         self.setpoint = self.sp_data[-1]

--- a/pylabnet/scripts/lasers/wlm_monitor_only.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_only.py
@@ -414,12 +414,9 @@ class Channel:
 
         # if self.sp_data already exists, keep its last value so that the
         # clear data functionality doesn't override the setpoint
-        try:
-            if len(self.sp_data) > 0:
-                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
-            else:
-                self.sp_data = np.ones(display_pts) * self.data[-1]
-        except:
+        if len(self.sp_data) > 0:
+            self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+        else:
             self.sp_data = np.ones(display_pts) * self.data[-1]
 
         self.setpoint = self.sp_data[-1]

--- a/pylabnet/scripts/lasers/wlm_monitor_only.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_only.py
@@ -84,7 +84,7 @@ class WlmMonitor:
             ))
 
     def toogle_laser(self):
-        self.self.widgets['curve'][0].hide()
+        self.widgets['curve'][0].hide()
 
     def set_parameters(self, channel_params):
         """ Instantiates new channel objects with given parameters and assigns them to the WlmMonitor
@@ -412,11 +412,18 @@ class Channel:
 
         self.data = np.ones(display_pts) * wavelength
 
-        self.sp_data = np.ones(display_pts) * self.data[-1]
-        self.setpoint = self.data[-1]
-        # self.setpoint_override = True
+        # if self.sp_data already exists, keep its last value so that the
+        # clear data functionality doesn't override the setpoint
+        try:
+            if len(self.sp_data) > 0:
+                self.sp_data = np.ones(display_pts) * self.sp_data[-1]
+            else:
+                self.sp_data = np.ones(display_pts) * self.data[-1]
+        except:
+            self.sp_data = np.ones(display_pts) * self.data[-1]
 
-        # self.lock_override = True
+        self.setpoint = self.sp_data[-1]
+
 
     def initialize_sp_data(self, display_pts=5000):
         self.sp_data = np.ones(display_pts) * self.data[-1]


### PR DESCRIPTION
PR title essentially explains it. Now when you click on clear plot:

<img width="720" alt="Screenshot 2022-11-08 at 12 05 49" src="https://user-images.githubusercontent.com/79099250/200629499-0becefdb-f77f-4332-b995-7c0e83300526.png">

It does not silently override the lock setpoint anymore.