### PR TITLE
HDAWG auto server host address finding

### DIFF
--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -6,7 +6,7 @@ for the Zurich Instruments HDAWG.
 """
 
 import zhinst.utils
-import zhinst
+import zhinst.ziPython
 import re
 import time
 import textwrap
@@ -97,9 +97,8 @@ class Driver():
 
         # try finding the server address
         discovery = zhinst.ziPython.ziDiscovery()
-        d_i = discovery.find(device_id).lower()
-        discovery_info = discovery.get(d_i)
-        server_address = discovery_info["serveraddress"]
+        device_properties = discovery.get(discovery.find(device_id))
+        server_address = device_properties["serveraddress"]
 
         # Connect to device and log print output, not the lambda expression.
         (daq, device, props) = self.log_stdout(

--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -6,7 +6,7 @@ for the Zurich Instruments HDAWG.
 """
 
 import zhinst.utils
-import zhinst.ziPython as zi
+import zhinst
 import re
 import time
 import textwrap
@@ -98,8 +98,9 @@ class Driver():
         err_msg = "This example can only be run on an HDAWG."
 
         # try finding the server address
-        discovery = zi.ziDiscovery()
-        discovery_info = discovery.get(device_id)
+        discovery = zhinst.ziPython.ziDiscovery()
+        d_i = discovery.find(device_id).lower()
+        discovery_info = discovery.get(d_i)
         server_address = discovery_info["serveraddress"]
 
         # Connect to device and log print output, not the lambda expression.
@@ -107,8 +108,6 @@ class Driver():
             lambda: zhinst.utils.create_api_session(
                 device_id,
                 api_level,
-                #server_host='127.0.0.1' # TODO: Read this from config file
-                #server_host='140.247.189.115'
                 server_host=server_address
             )
         )

--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -95,8 +95,6 @@ class Driver():
     def _setup_hdawg(self, device_id, logger, api_level, reset_dio, disable_everything):
         ''' Sets up HDAWG '''
 
-        err_msg = "This example can only be run on an HDAWG."
-
         # try finding the server address
         discovery = zhinst.ziPython.ziDiscovery()
         d_i = discovery.find(device_id).lower()

--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -6,6 +6,7 @@ for the Zurich Instruments HDAWG.
 """
 
 import zhinst.utils
+import zhinst.ziPython as zi
 import re
 import time
 import textwrap
@@ -96,12 +97,19 @@ class Driver():
 
         err_msg = "This example can only be run on an HDAWG."
 
+        # try finding the server address
+        discovery = zi.ziDiscovery()
+        discovery_info = discovery.get(device_id)
+        server_address = discovery_info["serveraddress"]
+
         # Connect to device and log print output, not the lambda expression.
         (daq, device, props) = self.log_stdout(
             lambda: zhinst.utils.create_api_session(
                 device_id,
                 api_level,
-                server_host='127.0.0.1' # TODO: Read this from config file
+                #server_host='127.0.0.1' # TODO: Read this from config file
+                #server_host='140.247.189.115'
+                server_host=server_address
             )
         )
 


### PR DESCRIPTION
Solves issue #354.

Before the server_host argument when creating an api session on the HDAWG had to be hardcoded. This led to errors when the server_host address changed. 

Now zhinst will instead look for and retrieve the server host address (based on a given device_id) and give it as an argument to the create api session function:

# try finding the server address
discovery = zhinst.ziPython.ziDiscovery()
d_i = discovery.find(device_id).lower()
discovery_info = discovery.get(d_i)
server_address = discovery_info["serveraddress"]

# Connect to device and log print output, not the lambda expression.
(daq, device, props) = self.log_stdout(
    lambda: zhinst.utils.create_api_session(
        device_id,
        api_level,
        server_host=server_address
    )
)

This code was tried on both Goldberry and Caleb (nonlocal server vs local server and seems to work.