### PR TITLE
Make DIO breakout box pin assignment more general

### DIFF
--- a/pylabnet/hardware/awg/awg_utils.py
+++ b/pylabnet/hardware/awg/awg_utils.py
@@ -2,15 +2,15 @@
 from pylabnet.utils.helper_methods import load_config
 
 
-def convert_awg_pin_to_dio_board(awgPinNumber, awg_dio_pin_mapping):
+def convert_awg_pin_to_dio_board(awgPinNumber, breakout_dio_pin_mapping):
     """Computes the corresponding board and channel number on the DIO breakout for the
         corresponding input awgPinNumber given the mapping specificed in the configuration
         file provided.
     """
 
     #Get base pin index for board 0,1 and 2,3
-    baseB01 = awg_dio_pin_mapping["B01_base"]
-    baseB23 = awg_dio_pin_mapping["B23_base"]
+    baseB01 = breakout_dio_pin_mapping["B01_base"]
+    baseB23 = breakout_dio_pin_mapping["B23_base"]
 
     currBase = 0
     board = 0

--- a/pylabnet/hardware/staticline/staticline.py
+++ b/pylabnet/hardware/staticline/staticline.py
@@ -4,7 +4,7 @@ from pylabnet.hardware.staticline.staticline_devices import registered_staticlin
 
 class Driver():
 
-    def __init__(self, name, logger, hardware_client, hardware_type, config, awg_dio_pin_mapping=None):
+    def __init__(self, name, logger, hardware_client, hardware_type, hardware_config, staticline_config):
         '''High level staticline class.
 
         This class is used in conjunction with hardware modules to send out digital
@@ -22,15 +22,10 @@ class Driver():
         :hardware_type: (str)
             Name of the hardware to be controlled, naming is determined by the
             device server name.
-        :config: (dict)
-            Contains parameters needed to setup the hardware as a staticline.
-        :awg_dio_pin_mapping: (dict)
-            For dio breakout driver:mapping configuration for awg's dio pin 
-                e.g.{
-                        "B01_base": 24,
-                        "B23_base": 8
-                    }
-            For other hardware: None
+        :hardware_config: (dict)
+            Parameters needed to setup the hardware controlling the associated staticlines.
+        :staticline_config: (dict)
+            Parameters about each individual staticline control.
         '''
 
         self.name = name
@@ -52,8 +47,8 @@ class Driver():
             name=name,
             log=self.log,
             hardware_client=hardware_client,
-            config=config,
-            awg_dio_pin_mapping=awg_dio_pin_mapping
+            hardware_config=hardware_config,
+            config=staticline_config
         )
 
     def up(self):

--- a/pylabnet/hardware/staticline/staticline_devices.py
+++ b/pylabnet/hardware/staticline/staticline_devices.py
@@ -13,27 +13,26 @@ class StaticLineHardwareHandler(ABC):
     which should correspond to setting the staticline to high or low, and
     to set up the hardware accordingly.
 
-    :hardware_client: (object)
-        Hardware client to be used to toggle the staticline.
-    :log: (object)
-        Instance of loghandler.
+
     :name: (str)
         Name of StaticLine instance.
-    :config: (dict)
-            Contains parameters needed to setup the hardware as a staticline.
+    :log: (object)
+        Instance of loghandler.
+    :hardware_client: (object)
+        Hardware client to be used to toggle the staticline.
+    :hardware_config: (dict)
+            Parameters needed to setup the hardware controlling the associated staticlines.
     :config: (int)
-            Contains type of staticline being configured (digital, analog, or adjustable digital)
-    :awg_dio_pin_mapping (dict)
-            Record awg_dio_pin_mapping (for hardware type == dio_breakout only). None if the hardware type is not dio_breakout
+            Parameters about staticline being configured (digital, analog, or adjustable digital)
     '''
 
-    def __init__(self, name, log, hardware_client, config, awg_dio_pin_mapping):
+    def __init__(self, name, log, hardware_client, hardware_config, config):
         self.name = name
         self.log = log
         self.hardware_client = hardware_client
         self.hardware_name = str(hardware_client.__class__).split('.')[-2]
+        self.hardware_config = hardware_config
         self.config = config
-        self.awg_dio_pin_mapping = awg_dio_pin_mapping
 
         self.setup()
         self.log.info(
@@ -182,7 +181,7 @@ class DioBreakout(StaticLineHardwareHandler):
         assignment_dict = load_config('dio_assignment_global')
 
         DIO_bit = assignment_dict[self.config['bit_name']]
-        self.board, self.channel = convert_awg_pin_to_dio_board(DIO_bit, self.awg_dio_pin_mapping)
+        self.board, self.channel = convert_awg_pin_to_dio_board(DIO_bit, self.hardware_config["dio_pin_mapping"])
 
         self.isHighVoltage = self.config['is_high_volt']
 

--- a/pylabnet/scripts/staticlines/staticline.py
+++ b/pylabnet/scripts/staticlines/staticline.py
@@ -7,7 +7,7 @@ import pylabnet.hardware.staticline.staticline as staticline
 from pylabnet.gui.pyqt.gui_windowbuilder import GUIWindowFromConfig
 
 from pylabnet.utils.logging.logger import LogHandler
-from pylabnet.utils.helper_methods import get_os, get_ip, unpack_launcher, load_script_config, find_client
+from pylabnet.utils.helper_methods import get_os, get_ip, load_device_config, load_script_config, find_client
 
 
 class StaticLineGUIGeneric():
@@ -53,7 +53,7 @@ class StaticLineGUIGeneric():
             #Try to find if we have a matching device client in staticline_clients
             try:
                 hardware_client = find_client(staticline_clients, self.config_dict, hardware_type, hardware_config, logger_client)
-                if (hardware_client == None):
+                if hardware_client is None:
                     logger_client.error('No staticline device found for device name: ' + device_name)
                     hardware_client_found = False
                 else:
@@ -64,26 +64,18 @@ class StaticLineGUIGeneric():
 
             # Iterate over all staticlines for that device and create a
             # driver instance for each line.
-            if (hardware_client_found):
+            if hardware_client_found:
                 for staticline_idx in range(len(device_params["staticline_names"])):
                     staticline_name = device_params["staticline_names"][staticline_idx]
 
                     # Store the staticline driver under the specified device name
-                    # if "dio_breakout", need to assign extra parameter (awg_dio_pin_mapping); otherwise don't
-                    if hardware_type == "dio_breakout":
-                        self.log.info("diobreakout!")
-                        self.log.info(device_params["awg_dio_pin_mapping"])
-                        awg_dio_pin_mapping = device_params["awg_dio_pin_mapping"]
-                    else:
-                        awg_dio_pin_mapping = None
-
                     self.staticlines[device_name][staticline_name] = staticline.Driver(
                         name=device_name + "_" + staticline_name,
                         logger=logger_client,
                         hardware_client=hardware_client,
                         hardware_type=hardware_type,
-                        config=device_params["staticline_configs"][staticline_idx],
-                        awg_dio_pin_mapping=awg_dio_pin_mapping
+                        hardware_config=load_device_config(hardware_type, hardware_config),
+                        staticline_config=device_params["staticline_configs"][staticline_idx]
                     )
 
                     # If the staticline has an initial default value, set that initially using set_value command


### PR DESCRIPTION
Fixes #350. The DIO breakout box needs a way to knowing how to convert from AWG channel numbers to the physical board & channel number on the breakout box. The old method uses a global config file `awg_dio_pin_mapping.json` that is of the form:
```
{
    "B01_base" : 8,
    "B23_base" : 24
}
```
where boards 0 and 1 are defined to cover the channels 8-15, while boards 2 and 3 cover the channels 24-31. However, since this is a global config, it means that this does not work for controlling DIO channels on other breakout boxes, which can occur if we (1) are controlling a different lab (2) have 2 breakout boxes on a single computer.

The new solution puts this information in each breakout box's device config file instead, so it will associated with the particular breakout box that are trying to access. The format is:
```
{
    "lab_name" : "B16",
    "resource_name":"ASRL5::INSTR",
    "device_id":"b16_breakout_second",
    "dio_pin_mapping": [
        {    
            "board_num": 0,
            "ch_start": 0,
            "ch_end": 3
        },
        {    
            "board_num": 1,
            "ch_start": 4,
            "ch_end": 7
        }
    ]
}
```
where we specify that board 0 covers channels 0~3, and so on. All breakout box device config files will now need the `dio_pin_mapping` field, but no changes will need to be made to the staticline configs. 