### PR TITLE
Make pywintpy only required on windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -94,7 +94,7 @@ python-kasa==0.4.0.dev2
 pytz==2021.1
 pyvisa==1.11.3
 pywin32==300; sys_platform=="win32"
-pywinpty==0.5.7
+pywinpty==0.5.7; sys_platform=="win32"
 PyYAML==5.4.1
 pyzmq==22.0.3
 qdarkstyle==2.8.1


### PR DESCRIPTION
Prevents the CI script from crashing since it uses Linux and can't install Windows packages.