### PR TITLE
Make startup error handling more robust

### DIFF
--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -21,8 +21,8 @@ from pylabnet.network.client_server.external_gui import Service, Client
 from pylabnet.utils.logging.logger import LogClient
 from pylabnet.launchers.launcher import Launcher
 from pylabnet.utils.helper_methods import (UnsupportedOSException, get_os, dict_to_str, load_config,
-    remove_spaces, create_server, hide_console, get_dated_subdirectory_filepath,
-    get_config_directory, load_device_config, launch_device_server, launch_script, get_ip)
+                                           remove_spaces, create_server, hide_console, get_dated_subdirectory_filepath,
+                                           get_config_directory, load_device_config, launch_device_server, launch_script, get_ip)
 
 if hasattr(QtCore.Qt, 'AA_EnableHighDpiScaling'):
     QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
@@ -293,11 +293,8 @@ class Controller:
             self.client_data[self.GUI_NAME + module_str] = self.log_service.client_data[self.GUI_NAME]
 
         # confluence handler and initiate confluence data into log's metadata
-        self.confluence_handler = LaunchControl_Confluence_Handler( self, self.app)
+        self.confluence_handler = LaunchControl_Confluence_Handler(self, self.app)
         self.confluence_handler.confluence_popup.okay_event(is_close=False)
-
-
-        
 
     def update_terminal(self, text):
         """ Updates terminal output on GUI """
@@ -383,8 +380,6 @@ class Controller:
 
         self.log_service.logger.info('log service succesfully started')
 
-
-
     def initialize_gui(self):
         """ Initializes basic GUI display """
 
@@ -423,7 +418,6 @@ class Controller:
         self.main_window.log_previous.setHidden(True)
         self.main_window.logfile_status_indicator.setEnabled(False)
         self.main_window.confluence_update.clicked.connect(self.confluence_info_update)
-
 
         # Configure list of scripts to run and clicking actions
         self._load_scripts()
@@ -551,7 +545,6 @@ class Controller:
                     if self.client_data[client]['lab_name'] == lab_name:
                         self.main_window.client_list.addItem(self.client_list[client])
                     self.client_list[client].setToolTip(info)
-
 
     def _stop_server(self):
         """ Stops the highlighted server, if applicable """
@@ -724,8 +717,6 @@ class Controller:
 
     def confluence_info_update(self):
         self.confluence_handler.confluence_popup.Popup_Update()
-
-        
 
     def _load_scripts(self):
         """ Loads all relevant scripts/devices from filesystem"""
@@ -1127,7 +1118,6 @@ class ProxyUpdater(QtCore.QObject):
                 self.update_signal.emit(new_msg)
 
 
-
 def main():
     """ Runs the launch controller """
 
@@ -1174,14 +1164,15 @@ def run(log_controller):
         updater.update_signal.connect(log_controller.update_proxy)
 
     else:
-        # Redirect sys.stdout to queue
-        queue = Queue()
-        sys.stdout = WriteStream(queue)
 
         # Instantiate GUI
         log_controller.start_logger()
         log_controller.initialize_gui()
         log_controller.start_gui_server()
+
+        # Redirect sys.stdout to queue
+        queue = Queue()
+        sys.stdout = WriteStream(queue)
 
         # Start logging os in master mode
         if log_controller.master:

--- a/pylabnet/launchers/launch_control.py
+++ b/pylabnet/launchers/launch_control.py
@@ -16,7 +16,7 @@ import numpy as np
 from pylabnet.utils.logging.logger import LogService
 from pylabnet.network.core.generic_server import GenericServer
 from pylabnet.network.core.client_base import ClientBase
-from pylabnet.gui.pyqt.external_gui import Window, ParameterPopup, LaunchControl_Confluence_Handler
+from pylabnet.gui.pyqt.external_gui import Window, ParameterPopup, LaunchControl_Confluence_Handler, warning_popup
 from pylabnet.network.client_server.external_gui import Service, Client
 from pylabnet.utils.logging.logger import LogClient
 from pylabnet.launchers.launcher import Launcher
@@ -125,12 +125,11 @@ class Controller:
             try:
                 static_proxy_dict = load_config('static_proxy')
             except:
-                print('No config found named static_proxy.json')
+                warning_popup('No config found named static_proxy.json')
                 time.sleep(10)
                 raise
             self.log_port = static_proxy_dict['master_log_port']
             self.gui_port = static_proxy_dict['master_gui_port']
-            hide_console()
         elif self.proxy:
             popup = ParameterPopup(
                 host=str,
@@ -145,14 +144,13 @@ class Controller:
             try:
                 static_proxy_dict = load_config('static_proxy')
             except:
-                print('No config found named static_proxy.json')
+                warning_popup('No config found named static_proxy.json')
                 time.sleep(10)
                 raise
             self.host = static_proxy_dict['master_ip']
             self.log_port = static_proxy_dict['master_log_port']
             self.gui_port = static_proxy_dict['master_gui_port']
             self.proxy = True
-            hide_console()
         else:
             self.log_port = self.LOG_PORT
             self.gui_port = self.GUI_PORT
@@ -377,7 +375,6 @@ class Controller:
                 print(f'Failed to insantiate Log Server at port {self.LOG_PORT}')
                 raise
         self.log_server.start()
-
         self.log_service.logger.info('log service succesfully started')
 
     def initialize_gui(self):
@@ -1121,7 +1118,6 @@ class ProxyUpdater(QtCore.QObject):
 def main():
     """ Runs the launch controller """
 
-    hide_console()
     log_controller = Controller()
     run(log_controller)
 

--- a/pylabnet/network/core/generic_server.py
+++ b/pylabnet/network/core/generic_server.py
@@ -23,7 +23,6 @@ software without authentication, change the default value to key=None here and i
 import rpyc
 import threading
 import os
-import time
 import platform
 
 
@@ -78,9 +77,8 @@ class GenericServer:
                 )
 
             else:
-                msg_str = f'No keyfile found, please check that {key} exists.'
+                msg_str = f'\nNo keyfile found, please check that {key} exists.\n'
                 print(msg_str)
-                time.sleep(10)
                 raise FileNotFoundError(msg_str)
 
         self._server_thread = threading.Thread(


### PR DESCRIPTION
For new computers, we often start up Pylabnet to find that it freezes and doesn't work. This is because:
1. The console window that the program is started in gets hidden during the startup process, so any error messages cannot be seen.
2. Any `print` messages get redirected to the logger, which makes sense in theory except in the case where the logger fails to set up, in which case all these messages are lost.

Changes:
1. Make the console window no longer hide upon starting up pylabnet.
2. Make the redirection to logger only happen after the logger has completed setup
3. Make the static_proxy missing error display a warning popup instead of printing.