### PR TITLE
Gefen data visualizer

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/data_visualizer.ui
+++ b/pylabnet/gui/pyqt/gui_templates/data_visualizer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1338</width>
-    <height>1001</height>
+    <width>1339</width>
+    <height>1101</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -40,6 +40,7 @@
         <property name="font">
          <font>
           <pointsize>12</pointsize>
+          <weight>50</weight>
           <italic>false</italic>
           <bold>false</bold>
          </font>
@@ -66,6 +67,7 @@
         <property name="font">
          <font>
           <pointsize>12</pointsize>
+          <weight>50</weight>
           <italic>false</italic>
           <bold>false</bold>
          </font>
@@ -89,6 +91,7 @@
         <property name="font">
          <font>
           <pointsize>12</pointsize>
+          <weight>50</weight>
           <italic>false</italic>
           <bold>false</bold>
          </font>
@@ -112,6 +115,7 @@
         <property name="font">
          <font>
           <pointsize>12</pointsize>
+          <weight>50</weight>
           <italic>false</italic>
           <bold>false</bold>
          </font>
@@ -135,6 +139,7 @@
         <property name="font">
          <font>
           <pointsize>12</pointsize>
+          <weight>50</weight>
           <italic>false</italic>
           <bold>false</bold>
          </font>
@@ -177,6 +182,7 @@
         <property name="font">
          <font>
           <pointsize>12</pointsize>
+          <weight>50</weight>
           <italic>false</italic>
           <bold>false</bold>
          </font>
@@ -210,7 +216,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0,0,0,0,0,0">
         <property name="sizeConstraint">
-         <enum>QLayout::SetMinimumSize</enum>
+         <enum>QLayout::SetNoConstraint</enum>
         </property>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -332,6 +338,13 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_2">
             <item>
+             <widget class="QPushButton" name="clear_y_matching">
+              <property name="text">
+               <string>Clear y matched data</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QLabel" name="param_5">
               <property name="maximumSize">
                <size>
@@ -343,6 +356,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
                <font>
                 <family>Calibri Light</family>
                 <pointsize>12</pointsize>
+                <weight>50</weight>
                 <italic>false</italic>
                 <bold>false</bold>
                </font>
@@ -381,6 +395,13 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_3">
             <item>
+             <widget class="QPushButton" name="y_match_check">
+              <property name="text">
+               <string>Help with matching y data</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QLabel" name="param_6">
               <property name="maximumSize">
                <size>
@@ -391,6 +412,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
               <property name="font">
                <font>
                 <pointsize>12</pointsize>
+                <weight>50</weight>
                 <italic>false</italic>
                 <bold>false</bold>
                </font>
@@ -632,6 +654,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <italic>false</italic>
               <bold>false</bold>
              </font>
@@ -658,6 +681,7 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
             <property name="font">
              <font>
               <pointsize>12</pointsize>
+              <weight>50</weight>
               <italic>false</italic>
               <bold>false</bold>
              </font>
@@ -687,8 +711,8 @@ color: rgb(255, 255, 255);</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1338</width>
-     <height>22</height>
+     <width>1339</width>
+     <height>21</height>
     </rect>
    </property>
   </widget>

--- a/pylabnet/scripts/data_center/visualize_data.py
+++ b/pylabnet/scripts/data_center/visualize_data.py
@@ -30,6 +30,8 @@ class DataVisualizer:
             host=get_ip()
         )
 
+        # hello
+
         # Configure list of experiments
         self.gui.config.setText(config_name)
         self.config = config

--- a/pylabnet/scripts/data_center/visualize_data.py
+++ b/pylabnet/scripts/data_center/visualize_data.py
@@ -12,6 +12,7 @@ from pylabnet.utils.logging.logger import LogHandler
 from pylabnet.gui.pyqt.external_gui import Window
 from pylabnet.utils.helper_methods import load_config, generic_save, unpack_launcher, save_metadata, load_script_config, find_client, get_ip
 from pylabnet.scripts.data_center import datasets
+import re
 
 
 REFRESH_RATE = 150   # refresh rate in ms, try increasing if GUI lags
@@ -29,8 +30,6 @@ class DataVisualizer:
             gui_template='data_visualizer',
             host=get_ip()
         )
-
-        # hello
 
         # Configure list of experiments
         self.gui.config.setText(config_name)
@@ -51,6 +50,8 @@ class DataVisualizer:
 
         self.gui.x_data_searchbar.textChanged.connect(self.update_data_list)
         self.gui.y_data_searchbar.textChanged.connect(self.update_data_list)
+        self.gui.y_match_check.clicked.connect(self.match_data_list)
+        self.gui.clear_y_matching.clicked.connect(self.update_data_list)
 
         self.gui.fit_method.itemClicked.connect(self.update_fit_method)
         self.gui.p0_val.textChanged.connect(self.p0_changed)
@@ -79,6 +80,32 @@ class DataVisualizer:
             self.gui.y_data.clear()
             self.gui.x_data.clear()
 
+    def match_data_list(self):
+        # new feature - if you press on x data (and check the box "Help with matching y data"), it will show you only the related y data:
+        try:
+            x_data_name = self.gui.x_data.currentItem().text()
+            self.log.info(f"x_data_name was pressed!")
+            pattern = r'_x(?=_\d{2}_\d{2}_\d{2}$)'
+            match = re.search(pattern, x_data_name)
+            self.log.info(f"x data = {x_data_name}, match = {match}")
+            if match:
+                extracted_x = match.group()
+                modified_string = re.sub(pattern, '', x_data_name) # without _x_
+                self.gui.y_data.clear() # don't care about the y search anymore
+                # self.gui.y_data.addItem(modified_string) # check the filename here
+
+                # add all the y data with a variance of a minute:
+                modified_string_var = modified_string[:-4]
+                self.gui.warning_msg.setText(f"Good! x_data = {x_data_name} search all y data that starts with {modified_string_var}")
+
+                for filename in os.listdir(self.data_path):
+                    if filename.endswith('.txt') and modified_string_var in filename:
+                        self.gui.y_data.addItem(filename[:-4])
+            else:
+                self.gui.warning_msg.setText(f"If you want y matching, please select a file with _x_ in its name")
+        except:
+            self.gui.warning_msg.setText("WARNING: no x-data selected. First select and then press help matching again.")
+
     def update_data_list(self):
         """ Updates list of x and y data """
 
@@ -90,11 +117,11 @@ class DataVisualizer:
 
         for filename in os.listdir(self.data_path):
             if filename.endswith('.txt'):
-
                 if x_search == "":
                     self.gui.x_data.addItem(filename[:-4])
                 else:
                     if x_search in filename:
+                        self.log.info(f"searching for {filename[:-4]}")
                         self.gui.x_data.addItem(filename[:-4])
 
                 if y_search == "":


### PR DESCRIPTION
Gefen:

Added the option of y matching data inside the Data visualizer. The goal is to simplify the process of plotting. 
There are 2 new bottoms to push:
![image](https://github.com/lukingroup/pylabnet/assets/26712226/8542bbfe-25d8-48d7-99c9-92ff262809f3)

Once you select an x data that has "_x_" in it and press "Help with matching y data" - it will show you on the Y-axis only the files that match (with a variance of 1 minute). For example:
![image](https://github.com/lukingroup/pylabnet/assets/26712226/5788253e-3cb0-432f-a3b9-7cf72e9b7d5d)
another example:
![image](https://github.com/lukingroup/pylabnet/assets/26712226/f8793e5e-9ce6-48c1-8fe1-f85c987ce7b7)

That's it! Now you will select the x file and get the y matched file automatically and plot in a second:
![image](https://github.com/lukingroup/pylabnet/assets/26712226/15eb18c6-cfcd-4cb1-8958-757ce15f1380)


Notes:
1. If you will press "Help with matching y data" without selecting any x-data you will see the message:
![image](https://github.com/lukingroup/pylabnet/assets/26712226/f8acf9bb-e780-4985-a9af-4679aa7359f4)

2. If you will press "Help with matching y data" after selecting a file without "_x_" in it, you will see the message:
![image](https://github.com/lukingroup/pylabnet/assets/26712226/8b9122e1-1041-44fc-a2f5-cb9c05e5a6d3)

3. You can always press the "Clear y matched data" to show all the y files without the new matching feature (up to your search values!)
