### PR TITLE
Datataker bugfixes

### DIFF
--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -1869,9 +1869,8 @@ class ErrorBarGraph(Dataset):
             self.curve.setOpts(x=self.x, height=0 * self.x, width=width)
             self.error_curve.setData(x=self.x, y=0 * self.x, height=0 * self.x, beam=width)
         else:
-            self.x = np.arange(0, len(self.data))
-            self.curve.setOpts(x=self.x, height=0 * self.x, width=0.5)
-            self.error_curve.setData(y=self.data, height=0 * self.x, beam=0.5)
+            self.curve.setOpts(x=[], height=[], width=0.5)
+            self.error_curve.setData(x=[], y=[], height=[], beam=0.5)
 
 
 class ErrorBarAveragedHistogram(ErrorBarGraph):
@@ -1934,6 +1933,20 @@ class ErrorBarPlot(Dataset):
 
         for child in self.children.values():
             child.update(**kwargs)
+
+    def clear_data(self):
+
+        self.data = None
+        self.error = None
+
+        if self.x is not None:
+            try:
+                width = (self.x[1] - self.x[0]) / 2
+            except IndexError:
+                width = 0.5
+            self.curve.setData(x=self.x, y=0 * self.x, height=0 * self.x, beam=width)
+        else:
+            self.curve.setData(x=[], y=[], height=[], beam=0.5)
 
 
 class PhotonErrorBarPlot(ErrorBarGraph):

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -1856,6 +1856,23 @@ class ErrorBarGraph(Dataset):
         for child in self.children.values():
             child.update(**kwargs)
 
+    def clear_data(self):
+
+        self.data = None
+        self.error = None
+
+        if self.x is not None:
+            try:
+                width = (self.x[1] - self.x[0]) / 2
+            except IndexError:
+                width = 0.5
+            self.curve.setOpts(x=self.x, height=0 * self.x, width=width)
+            self.error_curve.setData(x=self.x, y=0 * self.x, height=0 * self.x, beam=width)
+        else:
+            self.x = np.arange(0, len(self.data))
+            self.curve.setOpts(x=self.x, height=0 * self.x, width=0.5)
+            self.error_curve.setData(y=self.data, height=0 * self.x, beam=0.5)
+
 
 class ErrorBarAveragedHistogram(ErrorBarGraph):
     """ ErrorBar graph version of AveragedHistogram"""

--- a/pylabnet/scripts/data_center/take_data.py
+++ b/pylabnet/scripts/data_center/take_data.py
@@ -118,6 +118,7 @@ class DataTaker:
         """
 
         filepath = self.gui.exp.model().filePath(index)
+
         if not os.path.isdir(filepath):
             with open(filepath, 'r') as exp_file:
                 exp_content = exp_file.read()
@@ -129,7 +130,19 @@ class DataTaker:
             self.log.update_metadata(experiment_file=exp_content)
 
             self.cur_path = self.gui.exp.model().filePath(self.gui.exp.currentIndex())
-            self.exp_name = os.path.split(os.path.basename(self.cur_path))[1][:-3]
+
+            # build experiment name by turning path into module
+            # for example: folder1/folder2/exp.py --> folder1.folder2.exp
+            path_beyond_exp_path = self.cur_path.split('/')[len(self.exp_path.split(os.sep)):]
+            # remove .py
+            path_beyond_exp_path[-1] = path_beyond_exp_path[-1][:-3]
+
+            self.exp_name = ''
+            for module_path in path_beyond_exp_path:
+                self.exp_name += module_path
+                self.exp_name += '.'
+            # remove final '.'
+            self.exp_name = self.exp_name[:-1]
 
         self.load_init_dict(index)
 


### PR DESCRIPTION
2 issues are fixed with this pull request. 

1. #403 : experiment scripts that we're located in a folder could not be launched by the data taker and would throw an error:
![image-25](https://github.com/lukingroup/pylabnet/assets/79099250/b32a942d-11f5-46f8-a010-752ba9e60df5)

The issue was that if the experiment was in folder1/folder2/file.py, it would just import module file, but needed to import module folder1.folder2.file:
![image-26](https://github.com/lukingroup/pylabnet/assets/79099250/0a6d9a60-47de-40e6-b5d7-85b476971d3b)

This should also be in principle operating system agnostic.


2. #392 : there were still some datatypes not clearing reliably:
![image-27](https://github.com/lukingroup/pylabnet/assets/79099250/1aca7a94-bc82-4379-a6c8-fcd8535abdb7)

The issue was specifically with ErrorBarGraph and ErrorBarPlot. I rewrote a clear_data function for those classes to solve the issue.