### PR TITLE
Yancheng/iss379

### DIFF
--- a/demo/ifm/ifm_client.ipynb
+++ b/demo/ifm/ifm_client.ipynb
@@ -2,7 +2,775 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 152,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import sys\n",
+    "import traceback\n",
+    "import re\n",
+    "import os\n",
+    "import importlib.util\n",
+    "from pylabnet.utils.logging import logger\n",
+    "from pylabnet.utils.helper_methods import get_ip, parse_args, hide_console, create_server, load_config, load_script_config, load_device_config, launch_device_server\n",
+    "from pylabnet.network.client_server import external_gui\n",
+    "from pylabnet.network.core.service_base import ServiceBase\n",
+    "from pylabnet.network.core.generic_server import GenericServer\n",
+    "from pylabnet.gui.pyqt.external_gui import ParameterPopup, fresh_popup, warning_popup\n",
+    "from pylabnet.network.client_server import thorlabs_pm320e\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 153,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ModuleSpec(name='thorlabs_pm320e', loader=<_frozen_importlib_external.SourceFileLoader object at 0x0000020F13A8CAC0>, origin='C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\launchers\\\\servers\\\\thorlabs_pm320e.py')\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "module = 'thorlabs_pm320e'\n",
+    "server = module\n",
+    "\n",
+    "spec = importlib.util.spec_from_file_location(\n",
+    "    module,\n",
+    "    os.path.join(\n",
+    "        os.path.dirname(os.path.realpath('./../')),\n",
+    "        'pylabnet',\n",
+    "        'launchers',\n",
+    "        'servers',\n",
+    "        module + '.py'\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "print(spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 154,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mod = importlib.util.module_from_spec(spec)\n",
+    "spec.loader.exec_module(mod)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 155,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 155,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm_client = mod.Client(host='192.168.50.102', port=14928)\n",
+    "isinstance(pm_client, thorlabs_pm320e.Client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 156,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'thorlabs_pm320e' from 'C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\launchers\\\\servers\\\\thorlabs_pm320e.py'>"
+      ]
+     },
+     "execution_count": 156,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mod"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 157,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pylabnet.network.client_server.thorlabs_pm320e.Client"
+      ]
+     },
+     "execution_count": 157,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mod.Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 158,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "8.40439315e-11"
+      ]
+     },
+     "execution_count": 158,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm_client.get_power(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 159,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pylabnet.network.client_server.thorlabs_pm320e.Client"
+      ]
+     },
+     "execution_count": 159,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(pm_client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import imp\n",
+    "mypath = 'C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 165,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import imp\n",
+    "\n",
+    "mod2 = imp.load_source(module, mypath + module + \".py\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 166,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 166,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm_client_2 = mod2.Client(host='192.168.50.102', port=14928)\n",
+    "isinstance(pm_client_2, thorlabs_pm320e.Client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 167,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2263777232208"
+      ]
+     },
+     "execution_count": 167,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "id(pm_client_2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 168,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3.75808343e-11"
+      ]
+     },
+     "execution_count": 168,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm_client_2.get_power(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pylabnet.network.client_server.thorlabs_pm320e\n"
+     ]
+    }
+   ],
+   "source": [
+    "module = 'thorlabs_pm320e'\n",
+    "full_module_name = 'pylabnet.network.client_server.' + module\n",
+    "print(full_module_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 200,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ModuleSpec(name='thorlabs_pm320e', loader=<_frozen_importlib_external.SourceFileLoader object at 0x0000020F13A9A820>, origin='C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\thorlabs_pm320e.py')\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "server = module\n",
+    "\n",
+    "spec1 = importlib.util.spec_from_file_location(\n",
+    "    module,\n",
+    "    os.path.join(\n",
+    "        os.path.dirname(os.path.realpath('./../')),\n",
+    "        'pylabnet',\n",
+    "        'network',\n",
+    "        'client_server',\n",
+    "        module + '.py'\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "print(spec1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 201,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mod1 = importlib.util.module_from_spec(spec1)\n",
+    "spec1.loader.exec_module(mod1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 202,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'thorlabs_pm320e' from 'C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\thorlabs_pm320e.py'>"
+      ]
+     },
+     "execution_count": 202,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mod1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 208,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "thorlabs_pm320e.Client"
+      ]
+     },
+     "execution_count": 208,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mod1.Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 204,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 204,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm_client_1 = mod1.Client(host='192.168.50.102', port=14928)\n",
+    "\n",
+    "from pylabnet.network.client_server import thorlabs_pm320e\n",
+    "isinstance(pm_client_1, thorlabs_pm320e.Client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 205,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "thorlabs_pm320e.Client"
+      ]
+     },
+     "execution_count": 205,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(pm_client_1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 176,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pylabnet.network.client_server.thorlabs_pm320e.Client"
+      ]
+     },
+     "execution_count": 176,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(pm_client)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 206,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4.98796351e-11"
+      ]
+     },
+     "execution_count": 206,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pm_client_1.get_power(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pylabnet.network.client_server.thorlabs_pm320e.Client'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print( type(pm_client_1) )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pylabnet.network.client_server.thorlabs_pm320e.Client'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print( type(pm_client) )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 181,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pylabnet.network.client_server.thorlabs_pm320e.Client"
+      ]
+     },
+     "execution_count": 181,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 196,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 196,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pylabnet.network.client_server.thorlabs_pm320e as tmp\n",
+    "type(pm_client) is tmp.Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 194,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 211,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\thorlabs_pm320e.py'"
+      ]
+     },
+     "execution_count": 211,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mypath + module + '.py'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 212,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\thorlabs_pm320e'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[1;32m<ipython-input-212-8c5c1240383e>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m class_ = getattr(importlib.import_module(mypath + module + '.py'), \\\n\u001b[0m\u001b[0;32m      2\u001b[0m                  'Client')\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\__init__.py\u001b[0m in \u001b[0;36mimport_module\u001b[1;34m(name, package)\u001b[0m\n\u001b[0;32m    125\u001b[0m                 \u001b[1;32mbreak\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    126\u001b[0m             \u001b[0mlevel\u001b[0m \u001b[1;33m+=\u001b[0m \u001b[1;36m1\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 127\u001b[1;33m     \u001b[1;32mreturn\u001b[0m \u001b[0m_bootstrap\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_gcd_import\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mlevel\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mpackage\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlevel\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    128\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    129\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\_bootstrap.py\u001b[0m in \u001b[0;36m_gcd_import\u001b[1;34m(name, package, level)\u001b[0m\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\_bootstrap.py\u001b[0m in \u001b[0;36m_find_and_load\u001b[1;34m(name, import_)\u001b[0m\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\_bootstrap.py\u001b[0m in \u001b[0;36m_find_and_load_unlocked\u001b[1;34m(name, import_)\u001b[0m\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\_bootstrap.py\u001b[0m in \u001b[0;36m_call_with_frames_removed\u001b[1;34m(f, *args, **kwds)\u001b[0m\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\_bootstrap.py\u001b[0m in \u001b[0;36m_gcd_import\u001b[1;34m(name, package, level)\u001b[0m\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\_bootstrap.py\u001b[0m in \u001b[0;36m_find_and_load\u001b[1;34m(name, import_)\u001b[0m\n",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python38\\lib\\importlib\\_bootstrap.py\u001b[0m in \u001b[0;36m_find_and_load_unlocked\u001b[1;34m(name, import_)\u001b[0m\n",
+      "\u001b[1;31mModuleNotFoundError\u001b[0m: No module named 'C:\\\\Users\\\\Roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\thorlabs_pm320e'"
+     ]
+    }
+   ],
+   "source": [
+    "class_ = getattr(importlib.import_module(mypath + module + '.py'), \\\n",
+    "                 'Client')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 216,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'pylabnet.network.client_server.thorlabs_pm320e' from 'c:\\\\users\\\\roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\thorlabs_pm320e.py'>"
+      ]
+     },
+     "execution_count": 216,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = mypath + module + '.py'\n",
+    "test1 = \"pylabnet.network.client_server.thorlabs_pm320e\"\n",
+    "\n",
+    "importlib.import_module(test1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pylabnet.network.client_server.thorlabs_pm320e\n"
+     ]
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "module = importlib.import_module(test_str)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<module 'pylabnet.network.client_server.thorlabs_pm320e' from 'c:\\\\users\\\\roger\\\\pylabnet\\\\pylabnet\\\\network\\\\client_server\\\\thorlabs_pm320e.py'>"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,6 +786,40 @@
     "import matplotlib.pyplot as plt\n",
     "import time"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pylabnet.network.client_server.ifm.Client"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ifm.Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -143,11 +945,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "5c0372ed38b372118c24adb00d45654d76c8d10261533c5724e3f5fc1d75489a"
-  },
   "kernelspec": {
-   "display_name": "Python 3.8.8 64-bit",
+   "display_name": "env",
    "language": "python",
    "name": "python3"
   },
@@ -161,14 +960,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.8rc1"
   },
   "metadata": {
    "interpreter": {
     "hash": "ae9bda92a3193a9528aa9c24f8faf75759760232ca9dd8afb106f849eeb1a235"
    }
   },
-  "orig_nbformat": 3
+  "orig_nbformat": 3,
+  "vscode": {
+   "interpreter": {
+    "hash": "841d85210f60d2f5a71540c9c0103733ac8aa5dde32f2591f9574d67eac287fa"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/pylabnet/launchers/launcher.py
+++ b/pylabnet/launchers/launcher.py
@@ -42,7 +42,6 @@ import numpy as np
 import sys
 import traceback
 import re
-import os
 import importlib.util
 from pylabnet.utils.logging import logger
 from pylabnet.utils.helper_methods import get_ip, parse_args, hide_console, create_server, load_config, load_script_config, load_device_config, launch_device_server
@@ -230,17 +229,10 @@ class Launcher:
         """
         server = module
 
-        spec = importlib.util.spec_from_file_location(
-            module,
-            os.path.join(
-                os.path.dirname(os.path.realpath(__file__)),
-                'servers',
-                module + '.py'
-            )
-        )
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
-        self.clients[(server, device_id)] = mod.Client(host=host, port=port)
+        full_module_name = 'pylabnet.network.client_server.' + module
+        client_class = getattr(importlib.import_module(full_module_name), "Client")
+
+        self.clients[(server, device_id)] = client_class(host=host, port=port)
 
     def _launch_servers(self):
         """ Searches through active servers and connects/launches them """


### PR DESCRIPTION
When we want to remotely control a device through clients, the previous way was going through server file (located inside launchers/servers/...) and find the corresponding network module. However, since the server file also import other related module, it would also execute driver module and require driver' package to be installed in the client computer.

Specifically, the code (in the launcher) was written in a way:
```python
    spec = importlib.util.spec_from_file_location(
        module,
        os.path.join(
            os.path.dirname(os.path.realpath(__file__)),
            'servers',
            module + '.py'
        )
    )
    mod = importlib.util.module_from_spec(spec)
    spec.loader.exec_module(mod)
    self.clients[(server, device_id)] = mod.Client(host=host, port=port)
``` 
To handle the client part, it goes into the server file and execute the network module.


For example:
if one wants to use thorlabs_pm320e, the code in the servers part include:
```python
import pyvisa

from pylabnet.hardware.power_meter.thorlabs_pm320e import Driver
from pylabnet.network.core.generic_server import GenericServer
from pylabnet.network.client_server.thorlabs_pm320e import Service, Client
from pylabnet.utils.helper_methods import get_ip, hide_console, load_device_config

``` 
so that it finds the Client module and use it.

However, while it also includes driver part, if some package in the driver code is missing, the code still runs through driver and produce errors.


To solve it, I modified the launcher side code such that it directly goes to network side to find the Client class (in the default case). But if it fails to find the network direclt, it still uses the old-fashioned way


```python
        server = module

        try:
            full_module_name = 'pylabnet.network.client_server.' + module
            client_class = getattr(importlib.import_module(full_module_name), "Client")

            self.clients[(server, device_id)] = client_class(host=host, port=port)
        except:
            spec = importlib.util.spec_from_file_location(
                module,
                os.path.join(
                    os.path.dirname(os.path.realpath(__file__)),
                    'servers',
                    module + '.py'
                )
            )
            mod = importlib.util.module_from_spec(spec)
            spec.loader.exec_module(mod)
            self.clients[(server, device_id)] = mod.Client(host=host, port=port)


```        
