### PR TITLE
Iss379 multitab

### DIFF
--- a/pylabnet/gui/pyqt/external_gui.py
+++ b/pylabnet/gui/pyqt/external_gui.py
@@ -1409,6 +1409,103 @@ class Confluence_support_GraphPopup(QtWidgets.QWidget):
     def upload_pic(self):
         self.confluence_handler.confluence_popup.Popup_Upload()
         return
+    
+
+class Confluence_support_GraphPopupTabs(QtWidgets.QWidget):
+    """ Widget class for holding new graphs """
+
+    def __init__(self, **kwargs):
+
+        QtWidgets.QWidget.__init__(self)
+
+        # self.app = app
+
+        if 'window_title' in kwargs:
+            window_title = kwargs['window_title']
+        else:
+            window_title = 'Graph Holder'
+
+        if 'log' in kwargs:
+            self.log = kwargs['log']
+        else:
+            self.log = None
+
+        if 'app' in kwargs:
+            self.app = kwargs['app']
+        else:
+            self.app = None
+
+        if 'size' in kwargs:
+            self.setMinimumSize(*kwargs['size'])
+
+        # Confluence handler and its button
+        enable_confluence = True
+
+        self.confluence_handler = None
+
+        if(self.log is None):
+            enable_confluence = False
+
+        if(enable_confluence is True):
+            self.confluence_handler = Confluence_Handler(self, self.app, log_client=self.log)
+
+            extractAction_Upload = QtWidgets.QAction("&UPLOAD to CONFLUENCE", self)
+            extractAction_Upload.setShortcut("Ctrl+S")
+            extractAction_Upload.setStatusTip('Upload to the confluence page')
+            extractAction_Upload.triggered.connect(self.upload_pic)
+
+            extractAction_Update = QtWidgets.QAction("&CONFLUENCE SETTING", self)
+            extractAction_Update.setShortcut("Ctrl+X")
+            extractAction_Update.setStatusTip('The space and page names of confluence')
+            extractAction_Update.triggered.connect(self.update_setting)
+
+            mainMenu = QtWidgets.QMenuBar(self)
+
+            ActionMenu = mainMenu.addMenu('&Action')
+            ActionMenu.addAction(extractAction_Upload)
+            ActionMenu.addAction(extractAction_Update)
+
+
+     
+        self.outer_layout = QtWidgets.QVBoxLayout()
+        self.outer_layout.setContentsMargins(30, 30, 30, 30)
+
+
+        # keep track of number of tabs that are filled
+        self.num_tabs = 0
+
+        # Prep first tab
+        self.tabs = QtWidgets.QTabWidget()
+        self.tab1 = QtWidgets.QWidget()
+        self.tabs.addTab(self.tab1, kwargs["tablabel"])
+    
+        self.outer_layout.addWidget(self.tabs)
+
+        self.setWindowTitle(window_title)
+        self.setLayout(self.outer_layout)
+
+        # Prep the Graphlayout for 
+        self.tab1.GraphLayout =  QtWidgets.QVBoxLayout()
+        self.tab1.setLayout(self.tab1.GraphLayout)
+
+
+        self.show()
+
+    def update_setting(self):
+        self.confluence_handler.confluence_popup.Popup_Update()
+
+    def upload_pic(self):
+        self.confluence_handler.confluence_popup.Popup_Upload()
+        return
+    
+    def add_graph_to_new_tab(self, graph, label):
+        new_tab = QtWidgets.QWidget()
+        self.tabs.addTab(new_tab, label)
+        new_tab.GraphLayout =  QtWidgets.QVBoxLayout()
+        new_tab.setLayout(new_tab.GraphLayout)
+        new_tab.GraphLayout.addWidget(graph)
+        self.num_tabs += 1
+        return
 
 
 class Confluence_Handler():

--- a/pylabnet/gui/pyqt/external_gui.py
+++ b/pylabnet/gui/pyqt/external_gui.py
@@ -898,6 +898,28 @@ class GraphPopup(QtWidgets.QWidget):
         self.setLayout(self.graph_layout)
         self.show()
 
+class GraphPopupTabs(QtWidgets.QWidget):
+    """ Widget class for holding new graphs in tabbed mode """
+
+    def __init__(self, **kwargs):
+
+        QtWidgets.QWidget.__init__(self)
+
+        self.graph_layout = QtWidgets.QVBoxLayout()
+
+        # if 'window_title' in kwargs:
+        #     window_title = kwargs['window_title']
+        # else:
+            
+        window_title = 'TABS'
+
+        if 'size' in kwargs:
+            self.setMinimumSize(*kwargs['size'])
+
+        self.setWindowTitle(window_title)
+        self.setLayout(self.graph_layout)
+        self.show()
+
 
 class Plot:
     """ Class for plot widgets inside of a Window

--- a/pylabnet/gui/pyqt/external_gui.py
+++ b/pylabnet/gui/pyqt/external_gui.py
@@ -876,9 +876,8 @@ class ParameterPopup(QtWidgets.QWidget):
         self.parameters.emit(ret)
         self.close()
 
-
 class GraphPopup(QtWidgets.QWidget):
-    """ Widget class for holding new graphs """
+    """ Widget class for holding new graphs in tabbed mode """
 
     def __init__(self, **kwargs):
 
@@ -899,27 +898,56 @@ class GraphPopup(QtWidgets.QWidget):
         self.show()
 
 class GraphPopupTabs(QtWidgets.QWidget):
-    """ Widget class for holding new graphs in tabbed mode """
+    """ Widget class for holding new graphs """
 
     def __init__(self, **kwargs):
 
         QtWidgets.QWidget.__init__(self)
 
-        self.graph_layout = QtWidgets.QVBoxLayout()
-
-        # if 'window_title' in kwargs:
-        #     window_title = kwargs['window_title']
-        # else:
-            
-        window_title = 'TABS'
+        if 'window_title' in kwargs:
+            window_title = kwargs['window_title']
+        else:
+            window_title = 'Graph Holder'
 
         if 'size' in kwargs:
             self.setMinimumSize(*kwargs['size'])
 
         self.setWindowTitle(window_title)
-        self.setLayout(self.graph_layout)
+
+        self.tabs_enabled = True
+
+        self.outer_layout = QtWidgets.QVBoxLayout()
+        self.outer_layout.setContentsMargins(30, 30, 30, 30)
+
+
+
+        # keep track of number of tabs that are filled
+        self.num_tabs = 0
+
+        # Prep first tab
+        self.tabs = QtWidgets.QTabWidget()
+        self.tab1 = QtWidgets.QWidget()
+        self.tabs.addTab(self.tab1, kwargs["tablabel"])
+    
+        self.outer_layout.addWidget(self.tabs)
+
+        self.setWindowTitle(window_title)
+        self.setLayout(self.outer_layout)
+
+        # Prep the Graphlayout for 
+        self.tab1.GraphLayout =  QtWidgets.QVBoxLayout()
+        self.tab1.setLayout(self.tab1.GraphLayout)
+
         self.show()
 
+    def add_graph_to_new_tab(self, graph, label):
+        new_tab = QtWidgets.QWidget()
+        self.tabs.addTab(new_tab, label)
+        new_tab.GraphLayout =  QtWidgets.QVBoxLayout()
+        new_tab.setLayout(new_tab.GraphLayout)
+        new_tab.GraphLayout.addWidget(graph)
+        self.num_tabs += 1
+        return
 
 class Plot:
     """ Class for plot widgets inside of a Window

--- a/pylabnet/gui/pyqt/external_gui.py
+++ b/pylabnet/gui/pyqt/external_gui.py
@@ -1418,6 +1418,8 @@ class Confluence_support_GraphPopupTabs(QtWidgets.QWidget):
 
         QtWidgets.QWidget.__init__(self)
 
+        self.tabs_enabled = True
+
         # self.app = app
 
         if 'window_title' in kwargs:

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -407,12 +407,9 @@ class Dataset():
                 else:
                     # Check if we want to enable tabs 
                     tabs_enabled = self.gui.windows[kwargs['window']].tabs_enabled 
+                    
 
-                    if 'tablabel' in kwargs:
-                        tablabel = kwargs["tablabel"]
-                    else:
-                        tablabel = "Tab"
-          
+                
                 if('datetime_axis' in kwargs and kwargs['datetime_axis']):
                     date_axis = TimeAxisItem(orientation='bottom')
                     self.graph = pg.PlotWidget(axisItems={'bottom': date_axis})
@@ -421,18 +418,49 @@ class Dataset():
 
                 if tabs_enabled:
 
-                    # If first time populated, add to first tab
-                    if self.gui.windows[kwargs['window']].num_tabs == 0:
+                    num_tabs = self.gui.windows[kwargs['window']].num_tabs
+
+                    if 'tablabel' in kwargs:
+                        tablabel = kwargs["tablabel"]
+                    else:
+                        tablabel = f"Tab{num_tabs}"
+
+                    tab_widget_labels = [self.gui.windows[kwargs['window']].tabs.tabText(i) for i in range(num_tabs)]
+
+                    if tablabel in tab_widget_labels:
+                        tab_widget_graphlayout = self.gui.windows[kwargs['window']].tabs.widget(tab_widget_labels.index(tablabel)).GraphLayout
+
+                        # add to retrieved tab
+                        tab_widget_graphlayout.addWidget(
+                            self.graph
+                        )
+                        
+                    elif num_tabs == 0:
+
                         # add to first tab
                         self.gui.windows[kwargs['window']].tab1.GraphLayout.addWidget(
                             self.graph
                         )
                         self.gui.windows[kwargs['window']].num_tabs += 1
+
                     else:
                         self.gui.windows[kwargs['window']].add_graph_to_new_tab(               
-                        graph = self.graph,
-                        label = tablabel
-                    )
+                            graph = self.graph,
+                            label = tablabel
+                        )
+                    
+                    # # If first time populated, add to first tab
+                    # if num_tabs == 0:
+                    #     # add to first tab
+                    #     self.gui.windows[kwargs['window']].tab1.GraphLayout.addWidget(
+                    #         self.graph
+                    #     )
+                    #     self.gui.windows[kwargs['window']].num_tabs += 1
+                    # else:
+                    #     self.gui.windows[kwargs['window']].add_graph_to_new_tab(               
+                    #     graph = self.graph,
+                    #     label = tablabel
+                    # )
                 else:
  
                     self.gui.windows[kwargs['window']].graph_layout.addWidget(self.graph)

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -6,7 +6,7 @@ import time
 from PyQt5 import QtWidgets, QtCore
 
 from pyqtgraph.widgets.MatplotlibWidget import MatplotlibWidget
-from pylabnet.gui.pyqt.external_gui import Window, ParameterPopup, GraphPopup, Confluence_support_GraphPopup, Confluence_Handler
+from pylabnet.gui.pyqt.external_gui import Window, ParameterPopup, GraphPopup, Confluence_support_GraphPopup, Confluence_Handler, GraphPopupTabs
 from pylabnet.utils.logging.logger import LogClient, LogHandler
 from pylabnet.utils.helper_methods import save_metadata, generic_save, npy_generic_save, pyqtgraph_save, fill_2dlist, TimeAxisItem
 
@@ -366,14 +366,21 @@ class Dataset():
 
                     # self.gui.windows[kwargs['window']] = GraphPopup(
                     #     window_title=window_title, size=(700, 300))
+                    tabs_enables = kwargs['tabs_enabled']
+
+
 
                     if(self.enable_confluence):
                         self.gui.windows[kwargs['window']] = Confluence_support_GraphPopup(
                             app=None, gui=self.gui, log=self.log, window_title=window_title, size=(1000, 500)
                         )
+                    elif tabs_enables:
+                        self.gui.windows[kwargs['window']] = GraphPopupTabs(
+                            window_title=window_title, size=(700, 300), 
+                        )
                     else:
                         self.gui.windows[kwargs['window']] = GraphPopup(
-                            window_title=window_title, size=(700, 300)
+                            window_title=window_title, size=(700, 300), 
                         )
 
                 if('datetime_axis' in kwargs and kwargs['datetime_axis']):

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -30,7 +30,6 @@ def get_color_index(dataset, kwargs):
         except KeyError:
             tabs_enabled = False
         
-        
         if tabs_enabled:
             color_index = dataset.gui.windows[kwargs['window']].num_tabs - 1
         elif 'window' in kwargs:
@@ -475,19 +474,6 @@ class Dataset():
                             graph = self.graph,
                             label = tablabel
                         )
-                    
-                    # # If first time populated, add to first tab
-                    # if num_tabs == 0:
-                    #     # add to first tab
-                    #     self.gui.windows[kwargs['window']].tab1.GraphLayout.addWidget(
-                    #         self.graph
-                    #     )
-                    #     self.gui.windows[kwargs['window']].num_tabs += 1
-                    # else:
-                    #     self.gui.windows[kwargs['window']].add_graph_to_new_tab(               
-                    #     graph = self.graph,
-                    #     label = tablabel
-                    # )
                 else:
  
                     self.gui.windows[kwargs['window']].graph_layout.addWidget(self.graph)

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -203,11 +203,6 @@ class Dataset():
 
         color_index = get_color_index(self, kwargs)
 
-        # if 'color_index' in kwargs:
-        #     color_index = kwargs['color_index']
-        # else:
-        #     color_index = self.gui.graph_layout.count() - 1
-
         self.curve = self.graph.plot(
             pen=pg.mkPen(self.gui.COLOR_LIST[
                 np.mod(color_index, len(self.gui.COLOR_LIST))
@@ -428,7 +423,7 @@ class Dataset():
                             )
                     elif tabs_enabled:
                         self.gui.windows[kwargs['window']] = GraphPopupTabs(
-                            window_title=window_title, size=(700, 300), 
+                            window_title=window_title, size=(700, 300), tablabel = tablabel
                         )
                     else:
                         self.gui.windows[kwargs['window']] = GraphPopup(
@@ -866,10 +861,8 @@ class ManualOpenLoopScan(Dataset):
     def visualize(self, graph, **kwargs):
         self.handle_new_window(graph, **kwargs)
 
-        if 'color_index' in kwargs:
-            color_index = kwargs['color_index']
-        else:
-            color_index = self.gui.graph_layout.count() - 1
+        color_index = get_color_index(self, kwargs)
+
         self.curve = self.graph.plot(
             pen=pg.mkPen(self.gui.COLOR_LIST[
                 np.mod(color_index, len(self.gui.COLOR_LIST))
@@ -1930,21 +1923,6 @@ class ErrorBarGraph(Dataset):
 
         color_index = get_color_index(self, kwargs)
 
-        # if 'color_index' in kwargs:
-        #     color_index = kwargs['color_index']
-        # else:
-
-        #     if self.gui.windows[kwargs['window']].tabs_enabled:
-        #         color_index = self.gui.windows[kwargs['window']].num_tabs - 1
-
-        #     if 'window' in kwargs:
-
-        #         color_index = self.gui.windows[kwargs['window']].graph_layout.count() - 1
-        #     else:
-        #         color_index = self.gui.graph_layout.count() - 1
-
-
-
         self.curve = pg.BarGraphItem(x=[0], height=[0], brush=pg.mkBrush(self.gui.COLOR_LIST[
             np.mod(color_index, len(self.gui.COLOR_LIST))
         ]), width=0.5)
@@ -2016,10 +1994,8 @@ class ErrorBarPlot(Dataset):
         self.error = None
         self.handle_new_window(graph, **kwargs)
 
-        if 'color_index' in kwargs:
-            color_index = kwargs['color_index']
-        else:
-            color_index = self.gui.graph_layout.count() - 1
+        color_index = get_color_index(self, kwargs)
+
         self.curve = pg.ErrorBarItem(pen=pg.mkPen(self.gui.COLOR_LIST[
             np.mod(color_index, len(self.gui.COLOR_LIST))
         ]), symbol='o')

--- a/pylabnet/scripts/data_center/datasets.py
+++ b/pylabnet/scripts/data_center/datasets.py
@@ -13,6 +13,35 @@ from pylabnet.utils.helper_methods import save_metadata, generic_save, npy_gener
 import sys
 
 
+def get_color_index(dataset, kwargs):
+
+    if 'color_index' in kwargs:
+        color_index = kwargs['color_index']
+    else:
+
+        try:
+            tabs_enabled = dataset.gui.windows[kwargs['window']].tabs_enabled
+        
+        # If Window has not tabs
+        except AttributeError:
+            tabs_enabled = False
+
+        # If dataset is initial dataset
+        except KeyError:
+            tabs_enabled = False
+        
+        
+        if tabs_enabled:
+            color_index = dataset.gui.windows[kwargs['window']].num_tabs - 1
+        elif 'window' in kwargs:
+            color_index = dataset.gui.windows[kwargs['window']].graph_layout.count() - 1
+        else:
+            color_index = dataset.gui.graph_layout.count() - 1
+
+    return color_index
+
+
+
 class Dataset():
 
     def __init__(self, gui: Window, log: LogClient = None, data=None,
@@ -172,10 +201,13 @@ class Dataset():
 
         self.handle_new_window(graph, **kwargs)
 
-        if 'color_index' in kwargs:
-            color_index = kwargs['color_index']
-        else:
-            color_index = self.gui.graph_layout.count() - 1
+        color_index = get_color_index(self, kwargs)
+
+        # if 'color_index' in kwargs:
+        #     color_index = kwargs['color_index']
+        # else:
+        #     color_index = self.gui.graph_layout.count() - 1
+
         self.curve = self.graph.plot(
             pen=pg.mkPen(self.gui.COLOR_LIST[
                 np.mod(color_index, len(self.gui.COLOR_LIST))
@@ -1896,13 +1928,23 @@ class ErrorBarGraph(Dataset):
         self.error = None
         self.handle_new_window(graph, **kwargs)
 
-        if 'color_index' in kwargs:
-            color_index = kwargs['color_index']
-        else:
-            if 'window' in kwargs:
-                color_index = self.gui.windows[kwargs['window']].graph_layout.count() - 1
-            else:
-                color_index = self.gui.graph_layout.count() - 1
+        color_index = get_color_index(self, kwargs)
+
+        # if 'color_index' in kwargs:
+        #     color_index = kwargs['color_index']
+        # else:
+
+        #     if self.gui.windows[kwargs['window']].tabs_enabled:
+        #         color_index = self.gui.windows[kwargs['window']].num_tabs - 1
+
+        #     if 'window' in kwargs:
+
+        #         color_index = self.gui.windows[kwargs['window']].graph_layout.count() - 1
+        #     else:
+        #         color_index = self.gui.graph_layout.count() - 1
+
+
+
         self.curve = pg.BarGraphItem(x=[0], height=[0], brush=pg.mkBrush(self.gui.COLOR_LIST[
             np.mod(color_index, len(self.gui.COLOR_LIST))
         ]), width=0.5)


### PR DESCRIPTION
## Added multitab-functionality for the datataker

To save valuable screen space, datasets can now be added in different tabs. Here's a minimum working example:

```python
# Designate a window as using tabs by using "tabs_enabled"
  dataset.add_child(
      name='irl1',
      data_type=InfiniteRollingLine,
      data_length = 200,
      window='window1',
      window_title = "Window 1",
      tablabel = "Test_tab1 (contains three graphs)", # This is both the key of the tab and the displayed tab label
      tabs_enabled = True
  )
```

By adding the `tabs_enabled = True` keyword argument to the first mention of the window labelled `window1`, the window `window1` gets defined as a 'tabbed' window. From now on, the key `tablabel` is used to access the different tabs. To add more datasets to the first tab, the following syntax is used:

```python
 # Using the same window and the same tablabel will add it dataset to tab
    dataset.add_child(
        name='irl2',
        data_type=InfiniteRollingLine,
        data_length = 200,
        window='window1',
        tablabel = "Test_tab1 (contains three graphs)",
    )
    
    dataset.add_child(
        name='irl3',
        data_type=InfiniteRollingLine,
        data_length = 200,
        window='window1',
        tablabel = "Test_tab1 (contains three graphs)",
    )
``` 

This code generates the first tab:
![image](https://github.com/lukingroup/pylabnet/assets/4958226/e44d94dd-32d9-440e-82b2-4a27a3e924d5)
Additional tabs can be entered by giving a new value for the `tablabel` key:

```python
## Second Tab 

    # Using the same window and a different tablabel will create new tab
    dataset.add_child(
        name='irl4',
        data_type=InfiniteRollingLine,
        data_length = 200,
        window='window1',
        tablabel = "Test_tab2",
    )
```

This generates the second tab:
![image](https://github.com/lukingroup/pylabnet/assets/4958226/a5641255-0638-41b0-a7ac-e2ce03838ce5)

And finally, a third tab with two datasets can be added analogously to how the first tab is created:

```python
## Third Tab 
    dataset.add_child(
        name='histogram1',
        data_type=AveragedHistogram,
        window='window1',
        mapping = rebin_histogram,
        tablabel = "Test_tab3 (contains three graphs)",
    )

    dataset.add_child(
        name='histogram2',
        data_type=ErrorBarGraph,
        window='window1',
        mapping = rebin_histogram,
        tablabel = "Test_tab3 (contains three graphs)",
    )
```

![image](https://github.com/lukingroup/pylabnet/assets/4958226/4636fbca-3d55-4fe4-9105-52e7bc2de7e6)

Functionality has been tested for the Confluence-upload enabled and disabled data-taker, data saving has been checked. No careful evaluation of the performance has been performed, e.g. it is unclear if the graphs that are not displayed do still get rendered in the background. 

Closes #391.
