### PR TITLE
Issue 386: Add option for HDAWG to be accessed by USB or Ethernet

### DIFF
--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -58,7 +58,7 @@ class Driver():
         self.dummy = dummy
 
         # Setup HDAWG
-        self._setup_hdawg(device_id, logger, api_level, reset_dio, disable_everything)
+        self._setup_hdawg(device_id, interface, logger, api_level, reset_dio, disable_everything)
 
     @dummy_wrap
     def reset_DIO_outputs(self):
@@ -92,7 +92,7 @@ class Driver():
         return input_argument
 
     @dummy_wrap
-    def _setup_hdawg(self, device_id, logger, api_level, reset_dio, disable_everything):
+    def _setup_hdawg(self, device_id, interface, logger, api_level, reset_dio, disable_everything):
         ''' Sets up HDAWG '''
         # try finding the server address
         discovery = zhinst.ziPython.ziDiscovery()

--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -99,8 +99,6 @@ class Driver():
         device_properties = discovery.get(discovery.find(device_id))
         server_address = device_properties["serveraddress"]
 
-        #interface = "1GbE"  # For Ethernet connection.
-
         server_host = "localhost"
         server_port = 8004
         api_level = 6  # Maximum API level supported for all instruments.

--- a/pylabnet/hardware/awg/zi_hdawg.py
+++ b/pylabnet/hardware/awg/zi_hdawg.py
@@ -43,7 +43,7 @@ SAMPLING_RATE_DICT = {
 
 class Driver():
 
-    def __init__(self, device_id, logger, dummy=False, api_level=6, reset_dio=False, disable_everything=False, **kwargs):
+    def __init__(self, device_id, interface, logger, dummy=False, api_level=6, reset_dio=False, disable_everything=False, **kwargs):
         """ Instantiate AWG
 
         :logger: instance of LogClient class
@@ -99,7 +99,7 @@ class Driver():
         device_properties = discovery.get(discovery.find(device_id))
         server_address = device_properties["serveraddress"]
 
-        interface = "1GbE"  # For Ethernet connection.
+        #interface = "1GbE"  # For Ethernet connection.
 
         server_host = "localhost"
         server_port = 8004

--- a/pylabnet/launchers/servers/zi_hdawg.py
+++ b/pylabnet/launchers/servers/zi_hdawg.py
@@ -9,8 +9,30 @@ def launch(**kwargs):
     # Instantiate driver
     zi_logger = kwargs['logger']
 
-    device_id = load_device_config('zi_hdawg', kwargs['config'], logger=kwargs['logger'])['device_id']
-    interface = load_device_config('zi_hdawg', kwargs['config'], logger=kwargs['logger'])['interface'] #1GbE, USB etc.
+    config_dict = load_device_config('zi_hdawg', kwargs['config'], logger=kwargs['logger'])
+
+    if('device_id' in config_dict):
+        device_id = config_dict['device_id']
+    else:
+        zi_logger.error(
+            f"A device ID for the HDAWG is required! Please ensure there is a 'device_id' key-value pair in the config file."
+        )
+        device_id = None
+
+    if('interface' in config_dict):
+        interface = config_dict['interface'] #1GbE, USB etc.
+    else:
+        zi_logger.error(
+            f"An interface for the HDAWG is required! Please ensure there is an 'interface' key-value pair in the config file."
+        )
+        interface = None
+
+    if(interface is None or device_id is None):
+        zi_logger.error(
+            f"Missing required parameters in the config file. Failed to launch the zi_hdawg server."
+        )
+        return
+
     hd = Driver(device_id, interface, zi_logger)
 
     # Instantiate server

--- a/pylabnet/launchers/servers/zi_hdawg.py
+++ b/pylabnet/launchers/servers/zi_hdawg.py
@@ -10,7 +10,8 @@ def launch(**kwargs):
     zi_logger = kwargs['logger']
 
     device_id = load_device_config('zi_hdawg', kwargs['config'], logger=kwargs['logger'])['device_id']
-    hd = Driver(device_id, zi_logger)
+    interface = load_device_config('zi_hdawg', kwargs['config'], logger=kwargs['logger'])['interface'] #1GbE, USB etc.
+    hd = Driver(device_id, interface, zi_logger)
 
     # Instantiate server
     hd_service = Service()


### PR DESCRIPTION
- created key in config file for "interface"
- modified the device and launcher files for the hdawg to look for and save the value of this key from the config file

![image](https://github.com/lukingroup/pylabnet/assets/47065173/daf51e9c-7c2b-4909-ae43-32bcc0702156)

Sample output if config file includes the new interface key:
![image](https://github.com/lukingroup/pylabnet/assets/47065173/4226728f-f9c1-4735-855b-cee303132a6d)

Sample output if no interface key is found:
![image](https://github.com/lukingroup/pylabnet/assets/47065173/dfb4b603-9c56-42a9-8026-3c7881c168e4)

