### PR TITLE
Scan1d fixes (issue #435 and #172)

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/scan_1d.ui
+++ b/pylabnet/gui/pyqt/gui_templates/scan_1d.ui
@@ -524,6 +524,28 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="trac_1">
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>Calibri Light</family>
+              <pointsize>12</pointsize>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgb(175, 0, 175);</string>
+            </property>
+            <property name="text">
+             <string>Hide Trace</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="avg_1">
             <property name="maximumSize">
              <size>
@@ -538,10 +560,10 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">background-color: rgb(170, 170, 255);</string>
+             <string notr="true">background-color: rgb(186, 28, 49);</string>
             </property>
             <property name="text">
-             <string>Avg only</string>
+             <string>Hide Avg</string>
             </property>
             <property name="checkable">
              <bool>false</bool>
@@ -589,6 +611,28 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="trac_2">
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>Calibri Light</family>
+              <pointsize>12</pointsize>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgb(175, 0, 175);</string>
+            </property>
+            <property name="text">
+             <string>Hide Trace</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QPushButton" name="avg_2">
             <property name="maximumSize">
              <size>
@@ -603,10 +647,10 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">background-color: rgb(170, 170, 255);</string>
+             <string notr="true">background-color: rgb(186, 28, 49);</string>
             </property>
             <property name="text">
-             <string>Avg only</string>
+             <string>Hide Avg</string>
             </property>
             <property name="checkable">
              <bool>false</bool>
@@ -822,7 +866,7 @@ color: rgb(255, 255, 255);</string>
      <x>0</x>
      <y>0</y>
      <width>1948</width>
-     <height>26</height>
+     <height>21</height>
     </rect>
    </property>
   </widget>

--- a/pylabnet/scripts/sweeper/scan_1d.py
+++ b/pylabnet/scripts/sweeper/scan_1d.py
@@ -46,7 +46,7 @@ class Controller(MultiChSweep1D):
         )
         self.widgets = get_gui_widgets(self.gui, p_min=1, p_max=1, pts=1, config=1,
                                        graph=2, legend=2, clients=1, exp=1, exp_preview=1, configure=1, run=1,
-                                       autosave=1, save_name=1, save=1, reps=1, rep_tracker=1, avg=2)
+                                       autosave=1, save_name=1, save=1, reps=1, rep_tracker=1, avg=2, trac=2)
 
         # Configure default parameters
         self.min = self.widgets['p_min'].value()
@@ -125,8 +125,10 @@ class Controller(MultiChSweep1D):
         # https://stackoverflow.com/questions/60001583/pyqt5-slot-function-does-not-take-default-argument
         self.widgets['save'].pressed.connect(lambda: self.save())
         self.widgets['reps'].valueChanged.connect(self.set_reps)
-        self.widgets['avg'][0].clicked.connect(lambda: self._clear_show_trace(0))
-        self.widgets['avg'][1].clicked.connect(lambda: self._clear_show_trace(1))
+        self.widgets['avg'][0].clicked.connect(lambda: self._clear_show_avg(0))
+        self.widgets['avg'][1].clicked.connect(lambda: self._clear_show_avg(1))
+        self.widgets['trac'][0].clicked.connect(lambda: self._clear_show_trace(0))
+        self.widgets['trac'][1].clicked.connect(lambda: self._clear_show_trace(1))
         self.gui.fit.clicked.connect(self.fit_config)
 
         # Create legends
@@ -219,13 +221,17 @@ class Controller(MultiChSweep1D):
             self.widgets['run'].setStyleSheet('background-color: green')
             self.widgets['run'].setText('Run')
             for button in self.widgets['avg']:
-                button.setText('Avg only')
+                button.setText('Hide Avg')
+            for button in self.widgets['trac']:
+                button.setText('Hide Trace')
             self.log.info('Sweep experiment stopped')
         else:
             self.widgets['rep_tracker'].setValue(0)
             self.widgets['reps'].setValue(0)
             for button in self.widgets['avg']:
-                button.setText('Avg only')
+                button.setText('Hide Avg')
+            for button in self.widgets['trac']:
+                button.setText('Hide Trace')
             self.widgets['run'].setStyleSheet('background-color: green')
             self.widgets['run'].setText('Run')
             self.stop()
@@ -703,12 +709,29 @@ class Controller(MultiChSweep1D):
 
         # Check status of button
         try:
-            if self.widgets['avg'][index].text() == 'Avg only':
-                self.widgets['avg'][index].setText('Show trace')
+            if self.widgets['trac'][index].text() == 'Hide Trace':
+                self.widgets['trac'][index].setText('Show Trace')
                 self.widgets['graph'][index].removeItem(self.widgets['curve'][index])
             else:
-                self.widgets['avg'][index].setText('Avg only')
+                self.widgets['trac'][index].setText('Hide Trace')
                 self.widgets['graph'][index].addItem(self.widgets['curve'][index])
+        except KeyError:
+            pass
+
+    def _clear_show_avg(self, index):
+        """ Clears or shows the average scan trace of a graph
+
+        :param index: (int) index of graph
+        """
+
+        # Check status of button
+        try:
+            if self.widgets['avg'][index].text() == 'Hide Avg':
+                self.widgets['avg'][index].setText('Show Avg')
+                self.widgets['graph'][index].removeItem(self.widgets['curve_avg'][index])
+            else:
+                self.widgets['avg'][index].setText('Hide Avg')
+                self.widgets['graph'][index].addItem(self.widgets['curve_avg'][index])
         except KeyError:
             pass
 

--- a/pylabnet/scripts/sweeper/scan_1d.py
+++ b/pylabnet/scripts/sweeper/scan_1d.py
@@ -119,7 +119,7 @@ class Controller(MultiChSweep1D):
             client_item = QtWidgets.QListWidgetItem(client_name)
             client_item.setForeground(Qt.gray)
             self.widgets['clients'].addItem(client_item)
-            self.log.error("Datataker missing client: " + client_name)
+            self.log.error("Scan1D missing client: " + client_name)
 
         # Manually add logger to client
         self.clients['logger'] = logger


### PR DESCRIPTION
Fixes issue #435 
Before, had to access clients as: self.ctr = self.clients[('si_tt', 'sitt_b16')]
Now, changed to self.ctr = self.clients['si_tt_standard_ctr_b16'], which is the same as in datataker and also the name shown in the client list on the scan 1D GUI.

Also fixes issue #172 
Can now hide and show both average and trace curves (nice but not necessarily super useful)
<img width="1473" height="416" alt="{570D2BF7-9D98-479D-94FE-3B90CD45F42C}" src="https://github.com/user-attachments/assets/f508700e-dc16-446e-8119-282e6140fe7f" />
<img width="1468" height="408" alt="{1A2B4658-DD59-47EE-9C66-1964300641CB}" src="https://github.com/user-attachments/assets/bfa0ab22-bfe1-42c7-8f8e-613a25cb6424" />
<img width="1468" height="417" alt="{0E57FF4D-30FE-4536-B160-7FAC138A6B23}" src="https://github.com/user-attachments/assets/5f67e219-69e6-487e-87ce-d7e93312db5a" />
