### PR TITLE
Solve issues #469 and #470 (window sizing and view issues

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/data_taker.ui
+++ b/pylabnet/gui/pyqt/gui_templates/data_taker.ui
@@ -390,6 +390,12 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
               <property name="frameShape">
                <enum>QFrame::StyledPanel</enum>
               </property>
+              <property name="textElideMode">
+               <enum>Qt::ElideNone</enum>
+              </property>
+              <property name="horizontalScrollMode">
+               <enum>QAbstractItemView::ScrollPerPixel</enum>
+              </property>
              </widget>
             </item>
            </layout>
@@ -422,7 +428,26 @@ font: 25 12pt &quot;Calibri Light&quot;;</string>
              </widget>
             </item>
             <item>
-             <widget class="QTreeView" name="exp"/>
+             <widget class="QTreeView" name="exp">
+              <property name="horizontalScrollBarPolicy">
+               <enum>Qt::ScrollBarAsNeeded</enum>
+              </property>
+              <property name="alternatingRowColors">
+               <bool>false</bool>
+              </property>
+              <property name="textElideMode">
+               <enum>Qt::ElideNone</enum>
+              </property>
+              <attribute name="headerDefaultSectionSize">
+               <number>512</number>
+              </attribute>
+              <attribute name="headerMinimumSectionSize">
+               <number>256</number>
+              </attribute>
+              <attribute name="headerStretchLastSection">
+               <bool>false</bool>
+              </attribute>
+             </widget>
             </item>
            </layout>
           </item>
@@ -663,7 +688,7 @@ color: rgb(255, 255, 255);</string>
      <x>0</x>
      <y>0</y>
      <width>2565</width>
-     <height>26</height>
+     <height>21</height>
     </rect>
    </property>
   </widget>

--- a/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
+++ b/pylabnet/gui/pyqt/gui_templates/logger_remote.ui
@@ -67,6 +67,9 @@
       <property name="text">
        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Scripts:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
      </widget>
     </item>
     <item row="6" column="1">
@@ -226,7 +229,29 @@ color: rgb(255, 255, 255);</string>
      </widget>
     </item>
     <item row="1" column="4" rowspan="11">
-     <widget class="QTreeView" name="scripts"/>
+     <widget class="QTreeView" name="scripts">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>128</width>
+        <height>0</height>
+       </size>
+      </property>
+      <attribute name="headerDefaultSectionSize">
+       <number>502</number>
+      </attribute>
+      <attribute name="headerMinimumSectionSize">
+       <number>261</number>
+      </attribute>
+      <attribute name="headerStretchLastSection">
+       <bool>false</bool>
+      </attribute>
+     </widget>
     </item>
     <item row="0" column="5">
      <widget class="QLabel" name="label_4">
@@ -237,6 +262,9 @@ color: rgb(255, 255, 255);</string>
       </property>
       <property name="text">
        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Devices:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="margin">
+       <number>0</number>
       </property>
      </widget>
     </item>
@@ -330,7 +358,23 @@ background-color: green;</string>
      </widget>
     </item>
     <item row="1" column="5" rowspan="11">
-     <widget class="QTreeView" name="devices"/>
+     <widget class="QTreeView" name="devices">
+      <property name="minimumSize">
+       <size>
+        <width>128</width>
+        <height>0</height>
+       </size>
+      </property>
+      <attribute name="headerDefaultSectionSize">
+       <number>520</number>
+      </attribute>
+      <attribute name="headerMinimumSectionSize">
+       <number>260</number>
+      </attribute>
+      <attribute name="headerStretchLastSection">
+       <bool>false</bool>
+      </attribute>
+     </widget>
     </item>
     <item row="3" column="1">
      <widget class="QLabel" name="debug_label">


### PR DESCRIPTION
Now can see full datataker experiment names with horizontal scrollbar, and names don't get automatically shortened with ellipses:
<img width="534" height="682" alt="{FF419511-857C-4A77-9EBF-339DAEC70A0A}" src="https://github.com/user-attachments/assets/1d729162-0ad8-4bc9-8a48-9bfdaa425ad4" />

Same with staticproxy logger window, and also gave minimum Script and Device column width so that it's always reasonably viewable.