### PR TITLE
Fixed the plot naming for wavemeter

### DIFF
--- a/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor.ui
+++ b/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor.ui
@@ -54,6 +54,11 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+            </font>
+           </property>
            <property name="text">
             <string>Freq Plot 1</string>
            </property>
@@ -336,6 +341,11 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Freq Plot 2</string>
@@ -622,6 +632,11 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Voltage Plot 1</string>
@@ -923,6 +938,11 @@
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>16</pointsize>
+            </font>
            </property>
            <property name="text">
             <string>Voltage Plot 2</string>

--- a/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor.ui
+++ b/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor.ui
@@ -43,9 +43,22 @@
          <string notr="true"/>
         </property>
         <property name="title">
-         <string>Plot 1</string>
+         <string/>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QLabel" name="label_14">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Freq Plot 1</string>
+           </property>
+          </widget>
+         </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_4">
            <property name="sizeConstraint">
@@ -313,9 +326,22 @@
          <string notr="true"/>
         </property>
         <property name="title">
-         <string>Plot 1</string>
+         <string/>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QLabel" name="freq_plot_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Freq Plot 2</string>
+           </property>
+          </widget>
+         </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_6">
            <item>
@@ -586,9 +612,22 @@
          <string notr="true"/>
         </property>
         <property name="title">
-         <string>Plot 1</string>
+         <string/>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QLabel" name="volt_plot_1">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Voltage Plot 1</string>
+           </property>
+          </widget>
+         </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_5">
            <item>
@@ -874,9 +913,22 @@
          <string notr="true"/>
         </property>
         <property name="title">
-         <string>Plot 1</string>
+         <string/>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QLabel" name="volt_plot_2">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Voltage Plot 2</string>
+           </property>
+          </widget>
+         </item>
          <item>
           <layout class="QHBoxLayout" name="horizontalLayout_7">
            <item>

--- a/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor.ui
+++ b/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor.ui
@@ -47,7 +47,7 @@
         </property>
         <layout class="QVBoxLayout" name="verticalLayout">
          <item>
-          <widget class="QLabel" name="label_14">
+          <widget class="QLabel" name="freq_plot_1">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
              <horstretch>0</horstretch>

--- a/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor_3lasers.ui
+++ b/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor_3lasers.ui
@@ -190,9 +190,22 @@
         <string notr="true"/>
        </property>
        <property name="title">
-        <string>Plot 1</string>
+        <string/>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="freq_plot_1">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Freq Plot 1</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_4">
           <property name="sizeConstraint">
@@ -465,9 +478,22 @@
         <string notr="true"/>
        </property>
        <property name="title">
-        <string>Plot 1</string>
+        <string/>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QLabel" name="freq_plot_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Freq Plot 2</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_6">
           <item>
@@ -743,9 +769,22 @@
         <string notr="true"/>
        </property>
        <property name="title">
-        <string>Plot 1</string>
+        <string/>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QLabel" name="volt_plot_1">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Volt Plot 1</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_5">
           <item>
@@ -1031,9 +1070,22 @@
         <string notr="true"/>
        </property>
        <property name="title">
-        <string>Plot 1</string>
+        <string/>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <widget class="QLabel" name="volt_plot_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Volt Plot 2</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_7">
           <item>
@@ -1319,9 +1371,22 @@
         <string notr="true"/>
        </property>
        <property name="title">
-        <string>Plot 1</string>
+        <string/>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <widget class="QLabel" name="freq_plot_3">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Freq Plot 3</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_9">
           <property name="sizeConstraint">
@@ -1597,9 +1662,22 @@
         <string notr="true"/>
        </property>
        <property name="title">
-        <string>Plot 1</string>
+        <string/>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_6">
+        <item>
+         <widget class="QLabel" name="volt_plot_3">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Volt Plot 3</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_10">
           <item>

--- a/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor_3lasers.ui
+++ b/pylabnet/gui/pyqt/gui_templates/wavemeter_monitor_3lasers.ui
@@ -201,6 +201,11 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="font">
+           <font>
+            <pointsize>16</pointsize>
+           </font>
+          </property>
           <property name="text">
            <string>Freq Plot 1</string>
           </property>
@@ -488,6 +493,11 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>16</pointsize>
+           </font>
           </property>
           <property name="text">
            <string>Freq Plot 2</string>
@@ -779,6 +789,11 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>16</pointsize>
+           </font>
           </property>
           <property name="text">
            <string>Volt Plot 1</string>
@@ -1081,6 +1096,11 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="font">
+           <font>
+            <pointsize>16</pointsize>
+           </font>
+          </property>
           <property name="text">
            <string>Volt Plot 2</string>
           </property>
@@ -1382,6 +1402,11 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="font">
+           <font>
+            <pointsize>16</pointsize>
+           </font>
+          </property>
           <property name="text">
            <string>Freq Plot 3</string>
           </property>
@@ -1672,6 +1697,11 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>16</pointsize>
+           </font>
           </property>
           <property name="text">
            <string>Volt Plot 3</string>

--- a/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
@@ -320,11 +320,11 @@ class WlmMonitor:
             )
         elif channel.laser_lab is not None:
             self.widgets['freq_plot'][index].setText(
-                f'Freq Plot {channel.number} ({channel.name} - {channel.laser_lab})'
+                f'Freq Plot Ch {channel.number} ({channel.name} - {channel.laser_lab})'
             )
         else:
             self.widgets['freq_plot'][index].setText(
-                f'Freq Plot {channel.number} ({channel.name})'
+                f'Freq Plot Ch {channel.number} ({channel.name})'
             )
 
         # Create curves
@@ -392,11 +392,11 @@ class WlmMonitor:
             )
         elif channel.laser_lab is not None:
             self.widgets['volt_plot'][index].setText(
-                f'Volt Plot {channel.number} ({channel.name} - {channel.laser_lab})'
+                f'Volt Plot Ch {channel.number} ({channel.name} - {channel.laser_lab})'
             )
         else:
             self.widgets['volt_plot'][index].setText(
-                f'Volt Plot {channel.number} ({channel.name})'
+                f'Volt Plot Ch {channel.number} ({channel.name})'
             )
 
         # Error

--- a/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
@@ -851,7 +851,7 @@ def launch(**kwargs):
 
     logger = kwargs['logger']
     config = load_script_config(
-        script='wlm_monitor_b16',
+        script='wlm_monitor',
         config=kwargs['config'],
         logger=logger
     )

--- a/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
@@ -56,13 +56,15 @@ class WlmMonitor:
             self.widgets = get_gui_widgets(
                 gui=self.gui,
                 freq=3, sp=3, rs=3, lock=3, error_status=3, graph=6, legend=6, clear=6,
-                zero=6, voltage=3, error=3, P_laser=3, I_laser=3, D_laser=3, PID_upd_laser=3
+                zero=6, voltage=3, error=3, P_laser=3, I_laser=3, D_laser=3, PID_upd_laser=3,
+                freq_plot=3, volt_plot=3,
             )
         else:
             self.widgets = get_gui_widgets(
                 gui=self.gui,
                 freq=2, sp=2, rs=2, lock=2, error_status=2, graph=4, legend=4, clear=4,
-                zero=4, voltage=2, error=2, P_laser=2, I_laser=2, D_laser=2, PID_upd_laser=2
+                zero=4, voltage=2, error=2, P_laser=2, I_laser=2, D_laser=2, PID_upd_laser=2,
+                freq_plot=2, volt_plot=2,
             )
 
         # Set parameters
@@ -96,6 +98,9 @@ class WlmMonitor:
                 as a reference so that we know which channel to assign all the other parameters to
             - 'name': a string that can just be provided once and is used as a user-friendly name for the channel.
                 Initializes to 'Channel X' where X is a random integer if not provided
+            - 'laser_lab': a string that can just be provided once and is used as a user-friendly reference for the lab
+                name, specially useful in multiple-node exp. Left blank if not provided
+            - 'plot_name': a string that can be provided once and is used as the title of the plots for this channel
             - 'setpoint': setpoint for this channel.
             - 'lock': boolean that tells us whether or not to turn on the lock. Ignored if setpoint is None. Default is
                 False.
@@ -145,6 +150,12 @@ class WlmMonitor:
                     # Set all other parameters for this channel
                     if 'name' in parameter:
                         channel.name = parameter['name']
+
+                    if 'laser_lab' in parameter:
+                        channel.laser_lab = parameter['laser_lab']
+
+                    if 'plot_name' in parameter:
+                        channel.plot_name = parameter['plot_name']
 
                     if 'setpoint' in parameter:
 
@@ -301,6 +312,21 @@ class WlmMonitor:
             display_pts=self.display_pts
         )
 
+        # Create plot title
+        # frequency plot
+        if channel.plot_name is not None:
+            self.widgets['freq_plot'][index].setTitle(
+                f'{channel.plot_name}'
+            )
+        elif channel.laser_lab is not None:
+            self.widgets['freq_plot'][index].setTitle(
+                f'Freq Plot {channel.number} ({channel.name} - {channel.laser_lab})'
+            )
+        else:
+            self.widgets['freq_plot'][index].setTitle(
+                f'Freq Plot {channel.number} ({channel.name})'
+            )
+
         # Create curves
         # frequency
         self.widgets['curve'].append(self.widgets['graph'][2 * index].plot(
@@ -357,6 +383,21 @@ class WlmMonitor:
             curve=self.widgets['curve'][4 * index + 2],
             curve_name=channel.voltage_curve
         )
+
+        # Create plot title
+        # voltage plot
+        if channel.plot_name is not None:
+            self.widgets['volt_plot'][index].setTitle(
+                f'{channel.plot_name}'
+            )
+        elif channel.laser_lab is not None:
+            self.widgets['volt_plot'][index].setTitle(
+                f'Volt Plot {channel.number} ({channel.name} - {channel.laser_lab})'
+            )
+        else:
+            self.widgets['volt_plot'][index].setTitle(
+                f'Volt Plot {channel.number} ({channel.name})'
+            )
 
         # Error
         self.widgets['curve'].append(self.widgets['graph'][2 * index + 1].plot(
@@ -725,6 +766,16 @@ class Channel:
         self.curve_name = self.name + ' Frequency'  # Name used for identifying the frequency Curve object
         self.lock_name = self.name + ' Lock'  # Name used for identifying lock Scalar object
         self.error_name = self.name + ' Error'  # Name used for identifying error Scalar object
+
+        if 'laser_lab' in channel_params:
+            self.laser_lab = channel_params['laser_lab']
+        else:
+            self.laser_lab = None
+
+        if 'plot_name' in channel_params:
+            self.plot_name = channel_params['plot_name']
+        else:
+            self.plot_name = None
 
         if 'setpoint' in channel_params:
             self.setpoint = channel_params['setpoint']

--- a/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
+++ b/pylabnet/scripts/lasers/wlm_monitor_can_autolock.py
@@ -315,15 +315,15 @@ class WlmMonitor:
         # Create plot title
         # frequency plot
         if channel.plot_name is not None:
-            self.widgets['freq_plot'][index].setTitle(
+            self.widgets['freq_plot'][index].setText(
                 f'{channel.plot_name}'
             )
         elif channel.laser_lab is not None:
-            self.widgets['freq_plot'][index].setTitle(
+            self.widgets['freq_plot'][index].setText(
                 f'Freq Plot {channel.number} ({channel.name} - {channel.laser_lab})'
             )
         else:
-            self.widgets['freq_plot'][index].setTitle(
+            self.widgets['freq_plot'][index].setText(
                 f'Freq Plot {channel.number} ({channel.name})'
             )
 
@@ -387,15 +387,15 @@ class WlmMonitor:
         # Create plot title
         # voltage plot
         if channel.plot_name is not None:
-            self.widgets['volt_plot'][index].setTitle(
+            self.widgets['volt_plot'][index].setText(
                 f'{channel.plot_name}'
             )
         elif channel.laser_lab is not None:
-            self.widgets['volt_plot'][index].setTitle(
+            self.widgets['volt_plot'][index].setText(
                 f'Volt Plot {channel.number} ({channel.name} - {channel.laser_lab})'
             )
         else:
-            self.widgets['volt_plot'][index].setTitle(
+            self.widgets['volt_plot'][index].setText(
                 f'Volt Plot {channel.number} ({channel.name})'
             )
 


### PR DESCRIPTION
In channel params in the config file, one can now add parameters "laser_lab" and "plot_name" (as shown in picture attached) to specify lab and for both the lab and laser name to show up in plot name, or one can set a custom plot name to display instead. By default, it will only show the channel number and the laser name if the new parameters are not added 

<img width="852" height="1318" alt="image" src="https://github.com/user-attachments/assets/423fe430-f623-4479-bf5a-88b67dd9247c" />
