### PR TITLE
Remove buggy invisible characters causing CI crash + remove unused PYRPL folder

### DIFF
--- a/pylabnet/hardware/adjustable_filter/kurios_wb1.py
+++ b/pylabnet/hardware/adjustable_filter/kurios_wb1.py
@@ -1,4 +1,4 @@
-﻿from pyvisa import VisaIOError, ResourceManager
+from pyvisa import VisaIOError, ResourceManager
 import numpy as np
 from pylabnet.utils.logging.logger import LogHandler
 

--- a/pylabnet/hardware/power_meter/newport_2936.py
+++ b/pylabnet/hardware/power_meter/newport_2936.py
@@ -1,4 +1,4 @@
-﻿from pyvisa import VisaIOError, ResourceManager
+from pyvisa import VisaIOError, ResourceManager
 import numpy as np
 from pylabnet.utils.logging.logger import LogHandler
 


### PR DESCRIPTION
Two files contained an invalid non-printable character U+FEFF that caused the CI checker to keep crashing and throw errors. 

Also removed `pylabnet/YOUR_PYRPL_DESTINATION_FOLDER` which seemed to be unused?