### PR TITLE
change format to accept input given by wlm_monitor script

### DIFF
--- a/pylabnet/network/client_server/mcc_usb_3114.py
+++ b/pylabnet/network/client_server/mcc_usb_3114.py
@@ -25,8 +25,11 @@ class Service(ServiceBase):
 
 class Client(ClientBase):
 
-    def set_ao_voltage(self, ao_channel, voltage):
-        voltage_pickle = pickle.dumps(voltage)
+    def set_ao_voltage(self, ao_channel, voltages):
+        try:
+            voltage_pickle = pickle.dumps(voltages[0])
+        except:
+            voltage_pickle = pickle.dumps(voltages)
         return self._service.exposed_set_ao_voltage(
             ao_channel=ao_channel,
             voltage_pickle=voltage_pickle


### PR DESCRIPTION
wlm_monitor uses this:

self.ao['client'].set_ao_voltage(
    ao_channel=self.ao['channel'],
    voltages=[self.current_voltage]
)
so I updated mcc_usb_3114.py client_server file set_ao_voltage to:

def set_ao_voltage(self, ao_channel, voltages):
        try:
            voltage_pickle = pickle.dumps(voltages[0])
        except:
            voltage_pickle = pickle.dumps(voltages)
        return self._service.exposed_set_ao_voltage(
            ao_channel=ao_channel,
            voltage_pickle=voltage_pickle
        )

so it is compatible with with wlm (since Matisse piezo is controlled with mcc_usb_3114